### PR TITLE
Suggestion: instructions to use an alias to force recent fastboot

### DIFF
--- a/static/install.html
+++ b/static/install.html
@@ -62,6 +62,11 @@
             do not have support for current devices. Very old versions of <code>fastboot</code>
             from several years ago are still shipped by Linux distributions like Debian and lack
             the compatibility detection of modern versions so they can soft brick devices.</p>
+            <p>If you have simply downloaded the most recent 
+            <a href=https://developer.android.com/studio/releases/platform-tools>Android Platform Tools</a>,
+             to ensure the <code>fastboot</code> command uses this newly downloaded one, an option 
+            is to alias <code>fastboot</code> to the location of your downloaded fastboot, ie:</p>
+            <pre>alias fastboot='~/Downloads/platform-tools_r28.0.2-linux/fastboot'</pre>
             <h2 id="enabling-oem-unlocking">
                 Enabling OEM unlocking
                 <a href="#enabling-oem-unlocking">¶</a>


### PR DESCRIPTION
A simple option when downloading the most recent Android Platform Tools to make sure to use the associated recent fastboot is to alias to it. These instructions (hopefully) make it simple for the reader to do so.