### PR TITLE
fix device codenames in releases.html

### DIFF
--- a/static/releases.html
+++ b/static/releases.html
@@ -53,8 +53,8 @@
                     <ul>
                         <li><a href="#bonito-stable">Pixel 3a XL</a></li>
                         <li><a href="#sargo-stable">Pixel 3a</a></li>
-                        <li><a href="#blueline-stable">Pixel 3 XL</a></li>
-                        <li><a href="#crosshatch-stable">Pixel 3</a></li>
+                        <li><a href="#crosshatch-stable">Pixel 3 XL</a></li>
+                        <li><a href="#blueline-stable">Pixel 3</a></li>
                         <li><a href="#taimen-stable">Pixel 2 XL</a></li>
                         <li><a href="#walleye-stable">Pixel 2</a></li>
                         <li><a href="#marlin-stable">Pixel XL (legacy)</a></li>
@@ -66,8 +66,8 @@
                     <ul>
                         <li><a href="#bonito-beta">Pixel 3a XL</a></li>
                         <li><a href="#sargo-beta">Pixel 3a</a></li>
-                        <li><a href="#blueline-beta">Pixel 3 XL</a></li>
-                        <li><a href="#crosshatch-beta">Pixel 3</a></li>
+                        <li><a href="#crosshatch-beta">Pixel 3 XL</a></li>
+                        <li><a href="#blueline-beta">Pixel 3</a></li>
                         <li><a href="#taimen-beta">Pixel 2 XL</a></li>
                         <li><a href="#walleye-beta">Pixel 2</a></li>
                         <li><a href="#marlin-beta">Pixel XL (legacy)</a></li>


### PR DESCRIPTION
The codenames for the Pixel 3 XL and Pixel 3 were in the incorrect places.