### PR TITLE
Updated grapheneos.org design using material lite

### DIFF
--- a/static/build.html
+++ b/static/build.html
@@ -29,9 +29,9 @@
     <body>
         <nav>
             <ul>
-                <li><a href="/">GrapheneOS</a></li>
+                <li class="first"><a href="/">GrapheneOS</a></li>
                 <li><a href="./install.html">Install</a></li>
-                <li class="active"><a href="./build.html">Build</a></li>
+                <li><a href="./build.html" class="first">Build</a></li>
                 <li><a href="./usage.html">Usage</a></li>
                 <li><a href="./faq.html">FAQ</a></li>
                 <li><a href="./releases.html">Releases</a></li>

--- a/static/build.html
+++ b/static/build.html
@@ -2,40 +2,42 @@
 <html lang="en" prefix="og: http://ogp.me/ns#">
     <head>
         <meta charset="utf-8"/>
-        <title>Build | GrapheneOS</title>
-        <meta name="description" content="Building instructions for GrapheneOS, a security and privacy focused mobile OS with Android app compatibility."/>
+        <title>GrapheneOS</title>
+        <meta name="description" content="GrapheneOS is a security and privacy focused mobile OS with Android app compatibility."/>
         <meta name="theme-color" content="#212121"/>
         <meta name="msapplication-TileColor" content="#ffffff"/>
         <meta name="viewport" content="width=device-width, initial-scale=1"/>
         <meta name="twitter:site" content="@GrapheneOS"/>
         <meta name="twitter:creator" content="@GrapheneOS"/>
-        <meta property="og:title" content="GrapheneOS build documentation"/>
-        <meta property="og:description" content="Building instructions for GrapheneOS, a security and privacy focused mobile OS with Android app compatibility."/>
+        <meta property="og:title" content="GrapheneOS"/>
+        <meta property="og:description" content="GrapheneOS is a security and privacy focused mobile OS with Android app compatibility."/>
         <meta property="og:type" content="website"/>
         <meta property="og:image" content="https://grapheneos.org/opengraph.png"/>
         <meta property="og:image:width" content="512"/>
         <meta property="og:image:height" content="512"/>
         <meta property="og:image:alt" content="GrapheneOS logo"/>
-        <meta property="og:url" content="https://grapheneos.org/build"/>
+        <meta property="og:url" content="https://grapheneos.org/"/>
         <meta property="og:site_name" content="GrapheneOS"/>
         <link rel="icon" type="image/vnd.microsoft.icon" href="/favicon.ico"/>
         <link rel="mask-icon" href="/mask-icon.svg" color="#1a1a1a"/>
-        <link rel="stylesheet" href="/grapheneos.css?14"/>
+        <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+        <link rel="stylesheet" href="https://code.getmdl.io/1.3.0/material.indigo-pink.min.css">
+        <link rel="stylesheet" href="./grapheneos.css?14"/>
         <link rel="manifest" href="/manifest.webmanifest"/>
-        <link rel="canonical" href="https://grapheneos.org/build"/>
+        <link rel="canonical" href="https://grapheneos.org/"/>
     </head>
     <body>
         <nav>
             <ul>
-                <li><a href="/">GrapheneOS</a></li>
-                <li><a href="/install">Install</a></li>
-                <li class="active"><a href="/build">Build</a></li>
-                <li><a href="/usage">Usage</a></li>
-                <li><a href="/faq">FAQ</a></li>
-                <li><a href="/releases">Releases</a></li>
-                <li><a href="/source">Source</a></li>
-                <li><a href="/donate">Donate</a></li>
-                <li><a href="/contact">Contact</a></li>
+                <li class="active"><a href="/">GrapheneOS</a></li>
+                <li><a href="./install.html">Install</a></li>
+                <li><a href="./build.html">Build</a></li>
+                <li><a href="./usage.html">Usage</a></li>
+                <li><a href="./faq.html">FAQ</a></li>
+                <li><a href="./releases.html">Releases</a></li>
+                <li><a href="./source.html">Source</a></li>
+                <li><a href="./donate.html">Donate</a></li>
+                <li><a href="./contact.html">Contact</a></li>
             </ul>
         </nav>
         <div id="content">

--- a/static/build.html
+++ b/static/build.html
@@ -29,9 +29,9 @@
     <body>
         <nav>
             <ul>
-                <li class="first"><a href="/">GrapheneOS</a></li>
+                <li><a href="/">GrapheneOS</a></li>
                 <li><a href="./install.html">Install</a></li>
-                <li><a href="./build.html" class="first">Build</a></li>
+                <li class="active"><a href="./build.html">Build</a></li>
                 <li><a href="./usage.html">Usage</a></li>
                 <li><a href="./faq.html">FAQ</a></li>
                 <li><a href="./releases.html">Releases</a></li>

--- a/static/build.html
+++ b/static/build.html
@@ -22,7 +22,7 @@
         <link rel="mask-icon" href="/mask-icon.svg" color="#1a1a1a"/>
         <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
         <link rel="stylesheet" href="https://code.getmdl.io/1.3.0/material.indigo-pink.min.css">
-        <link rel="stylesheet" href="./grapheneos.css?14"/>
+        <link rel="stylesheet" href="/grapheneos.css?14"/>
         <link rel="manifest" href="/manifest.webmanifest"/>
         <link rel="canonical" href="https://grapheneos.org/"/>
     </head>
@@ -30,14 +30,14 @@
         <nav>
             <ul>
                 <li><a href="/" class="first">GrapheneOS</a></li>
-                <li><a href="./install.html">Install</a></li>
-                <li class="active"><a href="./build.html">Build</a></li>
-                <li><a href="./usage.html">Usage</a></li>
-                <li><a href="./faq.html">FAQ</a></li>
-                <li><a href="./releases.html">Releases</a></li>
-                <li><a href="./source.html">Source</a></li>
-                <li><a href="./donate.html">Donate</a></li>
-                <li><a href="./contact.html">Contact</a></li>
+                <li><a href="/install">Install</a></li>
+                <li class="active"><a href="/build">Build</a></li>
+                <li><a href="/usage">Usage</a></li>
+                <li><a href="/faq">FAQ</a></li>
+                <li><a href="/releases">Releases</a></li>
+                <li><a href="/source">Source</a></li>
+                <li><a href="/donate">Donate</a></li>
+                <li><a href="/contact">Contact</a></li>
             </ul>
         </nav>
         <div id="content">
@@ -249,7 +249,7 @@ repo init -u https://github.com/GrapheneOS/platform_manifest.git -b refs/tags/TA
 gpg --recv-keys 4340D13570EF945E83810964E8AD3F819AB10E78
 cd .repo/manifests
 git verify-tag --raw $(git describe)
-cd ../..</pre>
+cd ./..</pre>
 
             <p>Complete the source tree download:</p>
 
@@ -308,7 +308,7 @@ cd ../..</pre>
             <pre>cd kernel/google/crosshatch
 git submodule sync
 git submodule update --init
-./build.sh blueline</pre>
+/build.sh blueline</pre>
 
             <p>The <code>kernel/google/wahoo</code> repository is for the Pixel 2 and Pixel 2 XL
             and the <code>kernel/google/crosshatch</code> repository is for the Pixel 3, Pixel 3
@@ -438,14 +438,14 @@ mv vendor/android-prepare-vendor/DEVICE/BUILD_ID/vendor/google_devices/* vendor/
 
             <pre>mkdir -p keys/crosshatch
 cd keys/crosshatch
-../../development/tools/make_key releasekey '/CN=GrapheneOS/'
-../../development/tools/make_key platform '/CN=GrapheneOS/'
-../../development/tools/make_key shared '/CN=GrapheneOS/'
-../../development/tools/make_key media '/CN=GrapheneOS/'
-../../development/tools/make_key networkstack '/CN=GrapheneOS/'
+././development/tools/make_key releasekey '/CN=GrapheneOS/'
+././development/tools/make_key platform '/CN=GrapheneOS/'
+././development/tools/make_key shared '/CN=GrapheneOS/'
+././development/tools/make_key media '/CN=GrapheneOS/'
+././development/tools/make_key networkstack '/CN=GrapheneOS/'
 openssl genrsa -out avb.pem 2048
-../../external/avb/avbtool extract_public_key --key avb.pem --output avb_pkmd.bin
-cd ../..</pre>
+././external/avb/avbtool extract_public_key --key avb.pem --output avb_pkmd.bin
+cd ./..</pre>
 
             <p>The <code>avb_pkmd.bin</code> file isn't needed for generating a signed release but
             rather to set the public key used by the device to enforce verified boot.</p>
@@ -459,7 +459,7 @@ cd ../..</pre>
             done for each set of device keys):</p>
 
             <pre>cd keys/crosshatch
-../../development/tools/make_key networkstack '/CN=GrapheneOS/'</pre>
+././development/tools/make_key networkstack '/CN=GrapheneOS/'</pre>
 
             <h3 id="enabling-updatable-apex-components">
                 <a href="#enabling-updatable-apex-components">Enabling updatable APEX components</a>
@@ -590,7 +590,7 @@ git checkout $CORRECT_BRANCH_OR_TAG</pre>
             <p>Apply the GrapheneOS patches on top of the tagged release:</p>
 
             <pre>cd src
-git am --whitespace=nowarn ../*.patch</pre>
+git am --whitespace=nowarn ./*.patch</pre>
 
             <p>Generate a signing key for Vanadium if this is the initial build (the sample
             password configured in args.gn is <code>vanadiumpass</code>):</p>
@@ -603,7 +603,7 @@ git am --whitespace=nowarn ../*.patch</pre>
 
             <pre>gn args out/Default</pre>
 
-            <p>Copy the GrapheneOS configuration from <code>../args.gn</code> and save/exit the
+            <p>Copy the GrapheneOS configuration from <code>./args.gn</code> and save/exit the
             editor. Modify <code>target_cpu</code> as needed if the target is not arm64. For
             x86_64, the correct value for <code>target_cpu</code> is <code>x64</code>, but note
             that the Android source tree refers to it as x86_64.</p>
@@ -619,7 +619,7 @@ git am --whitespace=nowarn ../*.patch</pre>
 
             <p>Generate TrichromeChrome.apk from the bundle:</p>
 
-            <pre>../generate_trichrome_apk.sh</pre>
+            <pre>./generate_trichrome_apk.sh</pre>
 
             <p>The apks needs to be copied from <code>out/Default/apks/*.apk</code>
             into the Android source tree at
@@ -734,8 +734,8 @@ export ANDROID_HOME="$HOME/sdk"</pre>
 export PATH="$PATH:$HOME/sdk/tools:$HOME/sdk/tools/bin:$HOME/sdk/platform-tools:$HOME/sdk/build-tools/29.0.3:$HOME/sdk/ndk-bundle"</pre>
             <p>Copy media onto the device:</p>
             <pre>cd android-cts-media-1.4
-./copy_images.sh
-./copy_media.sh</pre>
+/copy_images.sh
+/copy_media.sh</pre>
 
             <p>You also need to do some basic setup for the device. It's possible for changes from
             a baseline install to cause interference, so it can be a good idea to factory reset
@@ -772,7 +772,7 @@ export PATH="$PATH:$HOME/sdk/tools:$HOME/sdk/tools/bin:$HOME/sdk/platform-tools:
             </h4>
 
             <p>Run the test harness:</p>
-            <pre>./android-cts/tools/cts-tradefed</pre>
+            <pre>/android-cts/tools/cts-tradefed</pre>
             <p>Note that <code>_JAVA_OPTIONS</code> being set will break the version detection.</p>
             <p>To obtain a list of CTS modules:</p>
             <pre>list modules</pre>

--- a/static/build.html
+++ b/static/build.html
@@ -29,9 +29,9 @@
     <body>
         <nav>
             <ul>
-                <li class="active"><a href="/">GrapheneOS</a></li>
+                <li><a href="/">GrapheneOS</a></li>
                 <li><a href="./install.html">Install</a></li>
-                <li><a href="./build.html">Build</a></li>
+                <li class="active"><a href="./build.html">Build</a></li>
                 <li><a href="./usage.html">Usage</a></li>
                 <li><a href="./faq.html">FAQ</a></li>
                 <li><a href="./releases.html">Releases</a></li>

--- a/static/build.html
+++ b/static/build.html
@@ -29,7 +29,7 @@
     <body>
         <nav>
             <ul>
-                <li><a href="/">GrapheneOS</a></li>
+                <li><a href="/" class="first">GrapheneOS</a></li>
                 <li><a href="./install.html">Install</a></li>
                 <li class="active"><a href="./build.html">Build</a></li>
                 <li><a href="./usage.html">Usage</a></li>

--- a/static/contact.html
+++ b/static/contact.html
@@ -29,7 +29,7 @@
     <body>
         <nav>
             <ul>
-                <li class="first"><a href="/">GrapheneOS</a></li>
+                <li><a href="/">GrapheneOS</a></li>
                 <li><a href="./install.html">Install</a></li>
                 <li><a href="./build.html">Build</a></li>
                 <li><a href="./usage.html">Usage</a></li>
@@ -37,7 +37,7 @@
                 <li><a href="./releases.html">Releases</a></li>
                 <li><a href="./source.html">Source</a></li>
                 <li><a href="./donate.html">Donate</a></li>
-                <li><a href="./contact.html" class="active">Contact</a></li>
+                <li class="active"><a href="./contact.html">Contact</a></li>
             </ul>
         </nav>
         <div id="content">

--- a/static/contact.html
+++ b/static/contact.html
@@ -22,7 +22,7 @@
         <link rel="mask-icon" href="/mask-icon.svg" color="#1a1a1a"/>
         <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
         <link rel="stylesheet" href="https://code.getmdl.io/1.3.0/material.indigo-pink.min.css">
-        <link rel="stylesheet" href="./grapheneos.css?14"/>
+        <link rel="stylesheet" href="/grapheneos.css?14"/>
         <link rel="manifest" href="/manifest.webmanifest"/>
         <link rel="canonical" href="https://grapheneos.org/"/>
     </head>
@@ -30,14 +30,14 @@
         <nav>
             <ul>
                 <li><a href="/" class="first">GrapheneOS</a></li>
-                <li><a href="./install.html">Install</a></li>
-                <li><a href="./build.html">Build</a></li>
-                <li><a href="./usage.html">Usage</a></li>
-                <li><a href="./faq.html">FAQ</a></li>
-                <li><a href="./releases.html">Releases</a></li>
-                <li><a href="./source.html">Source</a></li>
-                <li><a href="./donate.html">Donate</a></li>
-                <li class="active"><a href="./contact.html">Contact</a></li>
+                <li><a href="/install">Install</a></li>
+                <li><a href="/build">Build</a></li>
+                <li><a href="/usage">Usage</a></li>
+                <li><a href="/faq">FAQ</a></li>
+                <li><a href="/releases">Releases</a></li>
+                <li><a href="/source">Source</a></li>
+                <li><a href="/donate">Donate</a></li>
+                <li class="active"><a href="/contact">Contact</a></li>
             </ul>
         </nav>
         <div id="content">
@@ -58,8 +58,8 @@
             </h2>
             <p>The main forum currently used to discuss the project is the official
             <a href="https://reddit.com/r/GrapheneOS">/r/GrapheneOS subreddit</a> on Reddit.</p>
-            <p>The official IRC channel is #grapheneos on irc.freenode.net. The channel is bridged
-            to Matrix and is available at #grapheneos:matrix.org for Matrix users.</p>
+            <p>The official IRC channel is <code>#grapheneos</code> on <code>irc.freenode.net</code>. The channel is bridged
+            to Matrix and is available at <code>#grapheneos:matrix.org</code> for Matrix users.</p>
             <h2 id="reporting-issues">
                 <a href="#reporting-issues">Reporting issues</a>
             </h2>

--- a/static/contact.html
+++ b/static/contact.html
@@ -2,40 +2,42 @@
 <html lang="en" prefix="og: http://ogp.me/ns#">
     <head>
         <meta charset="utf-8"/>
-        <title>Contact | GrapheneOS</title>
-        <meta name="description" content="Contact information for GrapheneOS."/>
+        <title>GrapheneOS</title>
+        <meta name="description" content="GrapheneOS is a security and privacy focused mobile OS with Android app compatibility."/>
         <meta name="theme-color" content="#212121"/>
         <meta name="msapplication-TileColor" content="#ffffff"/>
         <meta name="viewport" content="width=device-width, initial-scale=1"/>
         <meta name="twitter:site" content="@GrapheneOS"/>
         <meta name="twitter:creator" content="@GrapheneOS"/>
-        <meta property="og:title" content="GrapheneOS contact information"/>
-        <meta property="og:description" content="Contact information for GrapheneOS."/>
+        <meta property="og:title" content="GrapheneOS"/>
+        <meta property="og:description" content="GrapheneOS is a security and privacy focused mobile OS with Android app compatibility."/>
         <meta property="og:type" content="website"/>
         <meta property="og:image" content="https://grapheneos.org/opengraph.png"/>
         <meta property="og:image:width" content="512"/>
         <meta property="og:image:height" content="512"/>
         <meta property="og:image:alt" content="GrapheneOS logo"/>
-        <meta property="og:url" content="https://grapheneos.org/contact"/>
+        <meta property="og:url" content="https://grapheneos.org/"/>
         <meta property="og:site_name" content="GrapheneOS"/>
         <link rel="icon" type="image/vnd.microsoft.icon" href="/favicon.ico"/>
         <link rel="mask-icon" href="/mask-icon.svg" color="#1a1a1a"/>
-        <link rel="stylesheet" href="/grapheneos.css?14"/>
+        <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+        <link rel="stylesheet" href="https://code.getmdl.io/1.3.0/material.indigo-pink.min.css">
+        <link rel="stylesheet" href="./grapheneos.css?14"/>
         <link rel="manifest" href="/manifest.webmanifest"/>
-        <link rel="canonical" href="https://grapheneos.org/contact"/>
+        <link rel="canonical" href="https://grapheneos.org/"/>
     </head>
     <body>
         <nav>
             <ul>
-                <li><a href="/">GrapheneOS</a></li>
-                <li><a href="/install">Install</a></li>
-                <li><a href="/build">Build</a></li>
-                <li><a href="/usage">Usage</a></li>
-                <li><a href="/faq">FAQ</a></li>
-                <li><a href="/releases">Releases</a></li>
-                <li><a href="/source">Source</a></li>
-                <li><a href="/donate">Donate</a></li>
-                <li class="active"><a href="/contact">Contact</a></li>
+                <li class="active"><a href="/">GrapheneOS</a></li>
+                <li><a href="./install.html">Install</a></li>
+                <li><a href="./build.html">Build</a></li>
+                <li><a href="./usage.html">Usage</a></li>
+                <li><a href="./faq.html">FAQ</a></li>
+                <li><a href="./releases.html">Releases</a></li>
+                <li><a href="./source.html">Source</a></li>
+                <li><a href="./donate.html">Donate</a></li>
+                <li><a href="./contact.html">Contact</a></li>
             </ul>
         </nav>
         <div id="content">

--- a/static/contact.html
+++ b/static/contact.html
@@ -29,7 +29,7 @@
     <body>
         <nav>
             <ul>
-                <li><a href="/">GrapheneOS</a></li>
+                <li><a href="/" class="first">GrapheneOS</a></li>
                 <li><a href="./install.html">Install</a></li>
                 <li><a href="./build.html">Build</a></li>
                 <li><a href="./usage.html">Usage</a></li>

--- a/static/contact.html
+++ b/static/contact.html
@@ -29,7 +29,7 @@
     <body>
         <nav>
             <ul>
-                <li class="active"><a href="/">GrapheneOS</a></li>
+                <li><a href="/">GrapheneOS</a></li>
                 <li><a href="./install.html">Install</a></li>
                 <li><a href="./build.html">Build</a></li>
                 <li><a href="./usage.html">Usage</a></li>
@@ -37,7 +37,7 @@
                 <li><a href="./releases.html">Releases</a></li>
                 <li><a href="./source.html">Source</a></li>
                 <li><a href="./donate.html">Donate</a></li>
-                <li><a href="./contact.html">Contact</a></li>
+                <li class="active"><a href="./contact.html">Contact</a></li>
             </ul>
         </nav>
         <div id="content">

--- a/static/contact.html
+++ b/static/contact.html
@@ -29,7 +29,7 @@
     <body>
         <nav>
             <ul>
-                <li><a href="/">GrapheneOS</a></li>
+                <li class="first"><a href="/">GrapheneOS</a></li>
                 <li><a href="./install.html">Install</a></li>
                 <li><a href="./build.html">Build</a></li>
                 <li><a href="./usage.html">Usage</a></li>
@@ -37,7 +37,7 @@
                 <li><a href="./releases.html">Releases</a></li>
                 <li><a href="./source.html">Source</a></li>
                 <li><a href="./donate.html">Donate</a></li>
-                <li class="active"><a href="./contact.html">Contact</a></li>
+                <li><a href="./contact.html" class="active">Contact</a></li>
             </ul>
         </nav>
         <div id="content">

--- a/static/donate.html
+++ b/static/donate.html
@@ -2,40 +2,42 @@
 <html lang="en" prefix="og: http://ogp.me/ns#">
     <head>
         <meta charset="utf-8"/>
-        <title>Donate | GrapheneOS</title>
-        <meta name="description" content="Donating to support development of GrapheneOS."/>
+        <title>GrapheneOS</title>
+        <meta name="description" content="GrapheneOS is a security and privacy focused mobile OS with Android app compatibility."/>
         <meta name="theme-color" content="#212121"/>
         <meta name="msapplication-TileColor" content="#ffffff"/>
         <meta name="viewport" content="width=device-width, initial-scale=1"/>
         <meta name="twitter:site" content="@GrapheneOS"/>
         <meta name="twitter:creator" content="@GrapheneOS"/>
-        <meta property="og:title" content="GrapheneOS donations"/>
-        <meta property="og:description" content="Donating to support development of GrapheneOS."/>
+        <meta property="og:title" content="GrapheneOS"/>
+        <meta property="og:description" content="GrapheneOS is a security and privacy focused mobile OS with Android app compatibility."/>
         <meta property="og:type" content="website"/>
         <meta property="og:image" content="https://grapheneos.org/opengraph.png"/>
         <meta property="og:image:width" content="512"/>
         <meta property="og:image:height" content="512"/>
         <meta property="og:image:alt" content="GrapheneOS logo"/>
-        <meta property="og:url" content="https://grapheneos.org/donate"/>
+        <meta property="og:url" content="https://grapheneos.org/"/>
         <meta property="og:site_name" content="GrapheneOS"/>
         <link rel="icon" type="image/vnd.microsoft.icon" href="/favicon.ico"/>
         <link rel="mask-icon" href="/mask-icon.svg" color="#1a1a1a"/>
-        <link rel="stylesheet" href="/grapheneos.css?14"/>
+        <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+        <link rel="stylesheet" href="https://code.getmdl.io/1.3.0/material.indigo-pink.min.css">
+        <link rel="stylesheet" href="./grapheneos.css?14"/>
         <link rel="manifest" href="/manifest.webmanifest"/>
-        <link rel="canonical" href="https://grapheneos.org/donate"/>
+        <link rel="canonical" href="https://grapheneos.org/"/>
     </head>
     <body>
         <nav>
             <ul>
-                <li><a href="/">GrapheneOS</a></li>
-                <li><a href="/install">Install</a></li>
-                <li><a href="/build">Build</a></li>
-                <li><a href="/usage">Usage</a></li>
-                <li><a href="/faq">FAQ</a></li>
-                <li><a href="/releases">Releases</a></li>
-                <li><a href="/source">Source</a></li>
-                <li class="active"><a href="/donate">Donate</a></li>
-                <li><a href="/contact">Contact</a></li>
+                <li class="active"><a href="/">GrapheneOS</a></li>
+                <li><a href="./install.html">Install</a></li>
+                <li><a href="./build.html">Build</a></li>
+                <li><a href="./usage.html">Usage</a></li>
+                <li><a href="./faq.html">FAQ</a></li>
+                <li><a href="./releases.html">Releases</a></li>
+                <li><a href="./source.html">Source</a></li>
+                <li><a href="./donate.html">Donate</a></li>
+                <li><a href="./contact.html">Contact</a></li>
             </ul>
         </nav>
         <div id="content">

--- a/static/donate.html
+++ b/static/donate.html
@@ -29,14 +29,14 @@
     <body>
         <nav>
             <ul>
-                <li class="active"><a href="/">GrapheneOS</a></li>
+                <li><a href="/">GrapheneOS</a></li>
                 <li><a href="./install.html">Install</a></li>
                 <li><a href="./build.html">Build</a></li>
                 <li><a href="./usage.html">Usage</a></li>
                 <li><a href="./faq.html">FAQ</a></li>
                 <li><a href="./releases.html">Releases</a></li>
                 <li><a href="./source.html">Source</a></li>
-                <li><a href="./donate.html">Donate</a></li>
+                <li class="active"><a href="./donate.html">Donate</a></li>
                 <li><a href="./contact.html">Contact</a></li>
             </ul>
         </nav>

--- a/static/donate.html
+++ b/static/donate.html
@@ -29,7 +29,7 @@
     <body>
         <nav>
             <ul>
-                <li><a href="/">GrapheneOS</a></li>
+                <li><a href="/" class="first">GrapheneOS</a></li>
                 <li><a href="./install.html">Install</a></li>
                 <li><a href="./build.html">Build</a></li>
                 <li><a href="./usage.html">Usage</a></li>

--- a/static/donate.html
+++ b/static/donate.html
@@ -29,14 +29,14 @@
     <body>
         <nav>
             <ul>
-                <li><a href="/">GrapheneOS</a></li>
+                <li class="first"><a href="/">GrapheneOS</a></li>
                 <li><a href="./install.html">Install</a></li>
                 <li><a href="./build.html">Build</a></li>
                 <li><a href="./usage.html">Usage</a></li>
                 <li><a href="./faq.html">FAQ</a></li>
                 <li><a href="./releases.html">Releases</a></li>
                 <li><a href="./source.html">Source</a></li>
-                <li class="active"><a href="./donate.html">Donate</a></li>
+                <li><a href="./donate.html" class="active">Donate</a></li>
                 <li><a href="./contact.html">Contact</a></li>
             </ul>
         </nav>

--- a/static/donate.html
+++ b/static/donate.html
@@ -29,14 +29,14 @@
     <body>
         <nav>
             <ul>
-                <li class="first"><a href="/">GrapheneOS</a></li>
+                <li><a href="/">GrapheneOS</a></li>
                 <li><a href="./install.html">Install</a></li>
                 <li><a href="./build.html">Build</a></li>
                 <li><a href="./usage.html">Usage</a></li>
                 <li><a href="./faq.html">FAQ</a></li>
                 <li><a href="./releases.html">Releases</a></li>
                 <li><a href="./source.html">Source</a></li>
-                <li><a href="./donate.html" class="active">Donate</a></li>
+                <li class="active"><a href="./donate.html">Donate</a></li>
                 <li><a href="./contact.html">Contact</a></li>
             </ul>
         </nav>

--- a/static/donate.html
+++ b/static/donate.html
@@ -22,7 +22,7 @@
         <link rel="mask-icon" href="/mask-icon.svg" color="#1a1a1a"/>
         <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
         <link rel="stylesheet" href="https://code.getmdl.io/1.3.0/material.indigo-pink.min.css">
-        <link rel="stylesheet" href="./grapheneos.css?14"/>
+        <link rel="stylesheet" href="/grapheneos.css?14"/>
         <link rel="manifest" href="/manifest.webmanifest"/>
         <link rel="canonical" href="https://grapheneos.org/"/>
     </head>
@@ -30,14 +30,14 @@
         <nav>
             <ul>
                 <li><a href="/" class="first">GrapheneOS</a></li>
-                <li><a href="./install.html">Install</a></li>
-                <li><a href="./build.html">Build</a></li>
-                <li><a href="./usage.html">Usage</a></li>
-                <li><a href="./faq.html">FAQ</a></li>
-                <li><a href="./releases.html">Releases</a></li>
-                <li><a href="./source.html">Source</a></li>
-                <li class="active"><a href="./donate.html">Donate</a></li>
-                <li><a href="./contact.html">Contact</a></li>
+                <li><a href="/install">Install</a></li>
+                <li><a href="/build">Build</a></li>
+                <li><a href="/usage">Usage</a></li>
+                <li><a href="/faq">FAQ</a></li>
+                <li><a href="/releases">Releases</a></li>
+                <li><a href="/source">Source</a></li>
+                <li class="active"><a href="/donate">Donate</a></li>
+                <li><a href="/contact">Contact</a></li>
             </ul>
         </nav>
         <div id="content">
@@ -60,7 +60,7 @@
             <h2 id="paypal">
                 <a href="#paypal">PayPal</a>
             </h2>
-            <p>PayPal donations can be sent to danielmicay@gmail.com. Please mention GrapheneOS in
+            <p>PayPal donations can be sent to <code>danielmicay@gmail.com</code>. Please mention GrapheneOS in
             the donation description to allow for proper record keeping, since PayPal
             <a href="https://www.paypal.com/ms/smarthelp/article/can-i-have-multiple-paypal-accounts-faq762">
             does not allow multiple personal accounts</a>.</p>

--- a/static/faq.html
+++ b/static/faq.html
@@ -22,7 +22,7 @@
         <link rel="mask-icon" href="/mask-icon.svg" color="#1a1a1a"/>
         <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
         <link rel="stylesheet" href="https://code.getmdl.io/1.3.0/material.indigo-pink.min.css">
-        <link rel="stylesheet" href="./grapheneos.css?14"/>
+        <link rel="stylesheet" href="/grapheneos.css?14"/>
         <link rel="manifest" href="/manifest.webmanifest"/>
         <link rel="canonical" href="https://grapheneos.org/"/>
     </head>
@@ -30,14 +30,14 @@
         <nav>
             <ul>
                 <li><a href="/" class="first">GrapheneOS</a></li>
-                <li><a href="./install.html">Install</a></li>
-                <li><a href="./build.html">Build</a></li>
-                <li><a href="./usage.html">Usage</a></li>
-                <li class="active"><a href="./faq.html">FAQ</a></li>
-                <li><a href="./releases.html">Releases</a></li>
-                <li><a href="./source.html">Source</a></li>
-                <li><a href="./donate.html">Donate</a></li>
-                <li><a href="./contact.html">Contact</a></li>
+                <li><a href="/install">Install</a></li>
+                <li><a href="/build">Build</a></li>
+                <li><a href="/usage">Usage</a></li>
+                <li class="active"><a href="/faq">FAQ</a></li>
+                <li><a href="/releases">Releases</a></li>
+                <li><a href="/source">Source</a></li>
+                <li><a href="/donate">Donate</a></li>
+                <li><a href="/contact">Contact</a></li>
             </ul>
         </nav>
         <div id="content">

--- a/static/faq.html
+++ b/static/faq.html
@@ -29,11 +29,11 @@
     <body>
         <nav>
             <ul>
-                <li class="active"><a href="/">GrapheneOS</a></li>
+                <li><a href="/">GrapheneOS</a></li>
                 <li><a href="./install.html">Install</a></li>
                 <li><a href="./build.html">Build</a></li>
                 <li><a href="./usage.html">Usage</a></li>
-                <li><a href="./faq.html">FAQ</a></li>
+                <li class="active"><a href="./faq.html">FAQ</a></li>
                 <li><a href="./releases.html">Releases</a></li>
                 <li><a href="./source.html">Source</a></li>
                 <li><a href="./donate.html">Donate</a></li>

--- a/static/faq.html
+++ b/static/faq.html
@@ -29,11 +29,11 @@
     <body>
         <nav>
             <ul>
-                <li class="first"><a href="/">GrapheneOS</a></li>
+                <li><a href="/">GrapheneOS</a></li>
                 <li><a href="./install.html">Install</a></li>
                 <li><a href="./build.html">Build</a></li>
                 <li><a href="./usage.html">Usage</a></li>
-                <li><a href="./faq.html" class="active">FAQ</a></li>
+                <li class="active"><a href="./faq.html">FAQ</a></li>
                 <li><a href="./releases.html">Releases</a></li>
                 <li><a href="./source.html">Source</a></li>
                 <li><a href="./donate.html">Donate</a></li>

--- a/static/faq.html
+++ b/static/faq.html
@@ -29,11 +29,11 @@
     <body>
         <nav>
             <ul>
-                <li><a href="/">GrapheneOS</a></li>
+                <li class="first"><a href="/">GrapheneOS</a></li>
                 <li><a href="./install.html">Install</a></li>
                 <li><a href="./build.html">Build</a></li>
                 <li><a href="./usage.html">Usage</a></li>
-                <li class="active"><a href="./faq.html">FAQ</a></li>
+                <li><a href="./faq.html" class="active">FAQ</a></li>
                 <li><a href="./releases.html">Releases</a></li>
                 <li><a href="./source.html">Source</a></li>
                 <li><a href="./donate.html">Donate</a></li>

--- a/static/faq.html
+++ b/static/faq.html
@@ -2,40 +2,42 @@
 <html lang="en" prefix="og: http://ogp.me/ns#">
     <head>
         <meta charset="utf-8"/>
-        <title>FAQ | GrapheneOS</title>
-        <meta name="description" content="Frequently asked questions about GrapheneOS."/>
+        <title>GrapheneOS</title>
+        <meta name="description" content="GrapheneOS is a security and privacy focused mobile OS with Android app compatibility."/>
         <meta name="theme-color" content="#212121"/>
         <meta name="msapplication-TileColor" content="#ffffff"/>
         <meta name="viewport" content="width=device-width, initial-scale=1"/>
         <meta name="twitter:site" content="@GrapheneOS"/>
         <meta name="twitter:creator" content="@GrapheneOS"/>
-        <meta property="og:title" content="GrapheneOS FAQ"/>
-        <meta property="og:description" content="Frequently asked questions about GrapheneOS."/>
+        <meta property="og:title" content="GrapheneOS"/>
+        <meta property="og:description" content="GrapheneOS is a security and privacy focused mobile OS with Android app compatibility."/>
         <meta property="og:type" content="website"/>
         <meta property="og:image" content="https://grapheneos.org/opengraph.png"/>
         <meta property="og:image:width" content="512"/>
         <meta property="og:image:height" content="512"/>
         <meta property="og:image:alt" content="GrapheneOS logo"/>
-        <meta property="og:url" content="https://grapheneos.org/faq"/>
+        <meta property="og:url" content="https://grapheneos.org/"/>
         <meta property="og:site_name" content="GrapheneOS"/>
         <link rel="icon" type="image/vnd.microsoft.icon" href="/favicon.ico"/>
         <link rel="mask-icon" href="/mask-icon.svg" color="#1a1a1a"/>
-        <link rel="stylesheet" href="/grapheneos.css?14"/>
+        <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+        <link rel="stylesheet" href="https://code.getmdl.io/1.3.0/material.indigo-pink.min.css">
+        <link rel="stylesheet" href="./grapheneos.css?14"/>
         <link rel="manifest" href="/manifest.webmanifest"/>
-        <link rel="canonical" href="https://grapheneos.org/faq"/>
+        <link rel="canonical" href="https://grapheneos.org/"/>
     </head>
     <body>
         <nav>
             <ul>
-                <li><a href="/">GrapheneOS</a></li>
-                <li><a href="/install">Install</a></li>
-                <li><a href="/build">Build</a></li>
-                <li><a href="/usage">Usage</a></li>
-                <li class="active"><a href="/faq">FAQ</a></li>
-                <li><a href="/releases">Releases</a></li>
-                <li><a href="/source">Source</a></li>
-                <li><a href="/donate">Donate</a></li>
-                <li><a href="/contact">Contact</a></li>
+                <li class="active"><a href="/">GrapheneOS</a></li>
+                <li><a href="./install.html">Install</a></li>
+                <li><a href="./build.html">Build</a></li>
+                <li><a href="./usage.html">Usage</a></li>
+                <li><a href="./faq.html">FAQ</a></li>
+                <li><a href="./releases.html">Releases</a></li>
+                <li><a href="./source.html">Source</a></li>
+                <li><a href="./donate.html">Donate</a></li>
+                <li><a href="./contact.html">Contact</a></li>
             </ul>
         </nav>
         <div id="content">

--- a/static/faq.html
+++ b/static/faq.html
@@ -29,7 +29,7 @@
     <body>
         <nav>
             <ul>
-                <li><a href="/">GrapheneOS</a></li>
+                <li><a href="/" class="first">GrapheneOS</a></li>
                 <li><a href="./install.html">Install</a></li>
                 <li><a href="./build.html">Build</a></li>
                 <li><a href="./usage.html">Usage</a></li>

--- a/static/grapheneos.css
+++ b/static/grapheneos.css
@@ -7,8 +7,8 @@ body {
     min-height: 100vh;
     min-height: -webkit-fill-available;
     font-family: Roboto, sans-serif;
-    background-color: #fafafa; /* grey50 */
-    color: rgba(0, 0, 0, 0.87); /* 87% black */
+    background-color: #fafafa;
+    color: rgba(0, 0, 0, 0.87);
     margin: 0;
     padding: 0;
     overflow-y: scroll;
@@ -19,12 +19,8 @@ body {
 }
 
 a {
-    color: #1565c0; /* blue800 */
+    color: #1565c0;
     text-decoration: none;
-}
-
-a:visited {
-    color: #6a1b9a; /* purple800 */
 }
 
 a:hover {
@@ -37,10 +33,14 @@ h1 a, h1 a:visited, h2 a, h2 a:visited, h3 a, h3 a:visited, h4 a, h4 a:visited, 
 
 pre {
     overflow-x: auto;
+    border: solid black 1px;
+    
 }
 
 code, pre {
     font-family: "Roboto Mono", monospace;
+    color: #c2185b;
+    padding: 10px;
 }
 
 nav ul {
@@ -52,31 +52,42 @@ nav ul {
 }
 
 nav {
-    background-color: #212121; /* grey900 */
-    box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12), 0 3px 1px -2px rgba(0, 0, 0, 0.2);
+    background-color: #c2185b;
+    -webkit-box-shadow: 0px 1px 5px 0px rgba(0,0,0,0.75);
+    -moz-box-shadow: 0px 1px 5px 0px rgba(0,0,0,0.75);
+    box-shadow: 0px 1px 5px 0px rgba(0,0,0,0.75);
 }
 
 nav ul li {
     list-style-type: none;
 }
 
-nav ul li:hover {
-    background-color: #424242; /* grey800 */
-}
-
 nav ul li a {
-    color: #fff; /* 100% white */
+    color: #e9acc4;
     display: block;
     text-decoration: none;
     padding: 1em;
+    font-size: medium;
+}
+
+nav ul li a.main {
+    font-weight: bold;
+    color: #000;
 }
 
 nav ul li a:visited {
-    color: #fff; /* 100% white */
+    color: #e9acc4;
 }
 
 nav ul li.active a {
-    color: #64b5f6; /* blue300 */
+    color: #fff;
+    border-bottom: 2px solid white;
+
+}
+
+nav ul li:hover > a{
+    color: #fff;
+    text-decoration: none;
 }
 
 #content {
@@ -88,6 +99,11 @@ nav ul li.active a {
     width: 100%;
     box-sizing: border-box;
     overflow-wrap: break-word;
+}
+
+#content a {
+    color: #c2185b;
+    font-weight: bold;
 }
 
 #bitcoin_address {
@@ -102,17 +118,14 @@ nav ul li.active a {
 }
 
 footer img {
-    width: 60px;
+    width: 75px;
     height: auto;
     display: block;
-    margin-left: auto;
-    margin-right: auto;
+    margin: 0 auto;
 }
 
 footer {
-    margin-top: auto;
-    margin-left: auto;
-    margin-right: auto;
+    margin: 0 auto;
     padding: 1em;
     max-width: 800px;
     overflow-wrap: break-word;
@@ -120,11 +133,12 @@ footer {
 }
 
 footer a {
-    color: #616161; /* grey500 */
+    color: #c2185b;
+    font-weight: bold;
 }
 
 footer a:visited {
-    color: #616161; /* grey500 */
+    color: #c2185b;
 }
 
 #social {

--- a/static/grapheneos.css
+++ b/static/grapheneos.css
@@ -70,11 +70,6 @@ nav ul li a {
     font-size: medium;
 }
 
-nav ul li a.main {
-    font-weight: bold;
-    color: #000;
-}
-
 nav ul li a:visited {
     color: #e9acc4;
 }
@@ -88,6 +83,11 @@ nav ul li.active a {
 nav ul li:hover > a{
     color: #fff;
     text-decoration: none;
+}
+
+nav ul li a.first {
+    font-weight: bold;
+    color: #fff;
 }
 
 #content {

--- a/static/grapheneos.css
+++ b/static/grapheneos.css
@@ -70,8 +70,9 @@ nav ul li a {
     font-size: medium;
 }
 
-nav ul li a.first {
+nav ul li a.main {
     font-weight: bold;
+    color: #000;
 }
 
 nav ul li a:visited {

--- a/static/grapheneos.css
+++ b/static/grapheneos.css
@@ -70,9 +70,8 @@ nav ul li a {
     font-size: medium;
 }
 
-nav ul li a.main {
+nav ul li a.first {
     font-weight: bold;
-    color: #000;
 }
 
 nav ul li a:visited {

--- a/static/index.html
+++ b/static/index.html
@@ -29,7 +29,7 @@
     <body>
         <nav>
             <ul>
-                <li class="active"><a href="/">GrapheneOS</a></li>
+                <li class="active"><a href="/" class="first">GrapheneOS</a></li>
                 <li><a href="./install.html">Install</a></li>
                 <li><a href="./build.html">Build</a></li>
                 <li><a href="./usage.html">Usage</a></li>

--- a/static/index.html
+++ b/static/index.html
@@ -20,7 +20,9 @@
         <meta property="og:site_name" content="GrapheneOS"/>
         <link rel="icon" type="image/vnd.microsoft.icon" href="/favicon.ico"/>
         <link rel="mask-icon" href="/mask-icon.svg" color="#1a1a1a"/>
-        <link rel="stylesheet" href="/grapheneos.css?14"/>
+        <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+        <link rel="stylesheet" href="https://code.getmdl.io/1.3.0/material.indigo-pink.min.css">
+        <link rel="stylesheet" href="./grapheneos.css?14"/>
         <link rel="manifest" href="/manifest.webmanifest"/>
         <link rel="canonical" href="https://grapheneos.org/"/>
     </head>
@@ -28,14 +30,14 @@
         <nav>
             <ul>
                 <li class="active"><a href="/">GrapheneOS</a></li>
-                <li><a href="/install">Install</a></li>
-                <li><a href="/build">Build</a></li>
-                <li><a href="/usage">Usage</a></li>
-                <li><a href="/faq">FAQ</a></li>
-                <li><a href="/releases">Releases</a></li>
-                <li><a href="/source">Source</a></li>
-                <li><a href="/donate">Donate</a></li>
-                <li><a href="/contact">Contact</a></li>
+                <li><a href="./install.html">Install</a></li>
+                <li><a href="./build.html">Build</a></li>
+                <li><a href="./usage.html">Usage</a></li>
+                <li><a href="./faq.html">FAQ</a></li>
+                <li><a href="./releases.html">Releases</a></li>
+                <li><a href="./source.html">Source</a></li>
+                <li><a href="./donate.html">Donate</a></li>
+                <li><a href="./contact.html">Contact</a></li>
             </ul>
         </nav>
         <div id="content">

--- a/static/index.html
+++ b/static/index.html
@@ -20,9 +20,7 @@
         <meta property="og:site_name" content="GrapheneOS"/>
         <link rel="icon" type="image/vnd.microsoft.icon" href="/favicon.ico"/>
         <link rel="mask-icon" href="/mask-icon.svg" color="#1a1a1a"/>
-        <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
-        <link rel="stylesheet" href="https://code.getmdl.io/1.3.0/material.indigo-pink.min.css">
-        <link rel="stylesheet" href="./grapheneos.css?14"/>
+        <link rel="stylesheet" href="/grapheneos.css?14"/>
         <link rel="manifest" href="/manifest.webmanifest"/>
         <link rel="canonical" href="https://grapheneos.org/"/>
     </head>
@@ -30,14 +28,14 @@
         <nav>
             <ul>
                 <li class="active"><a href="/">GrapheneOS</a></li>
-                <li><a href="./install">Install</a></li>
-                <li><a href="./build">Build</a></li>
-                <li><a href="./usage">Usage</a></li>
-                <li><a href="./faq">FAQ</a></li>
-                <li><a href="./releases">Releases</a></li>
-                <li><a href="./source">Source</a></li>
-                <li><a href="./donate">Donate</a></li>
-                <li><a href="./contact">Contact</a></li>
+                <li><a href="/install">Install</a></li>
+                <li><a href="/build">Build</a></li>
+                <li><a href="/usage">Usage</a></li>
+                <li><a href="/faq">FAQ</a></li>
+                <li><a href="/releases">Releases</a></li>
+                <li><a href="/source">Source</a></li>
+                <li><a href="/donate">Donate</a></li>
+                <li><a href="/contact">Contact</a></li>
             </ul>
         </nav>
         <div id="content">

--- a/static/index.html
+++ b/static/index.html
@@ -29,7 +29,7 @@
     <body>
         <nav>
             <ul>
-                <li class="active"><a href="/" class="first">GrapheneOS</a></li>
+                <li class="active"><a href="/">GrapheneOS</a></li>
                 <li><a href="./install.html">Install</a></li>
                 <li><a href="./build.html">Build</a></li>
                 <li><a href="./usage.html">Usage</a></li>

--- a/static/index.html
+++ b/static/index.html
@@ -20,7 +20,9 @@
         <meta property="og:site_name" content="GrapheneOS"/>
         <link rel="icon" type="image/vnd.microsoft.icon" href="/favicon.ico"/>
         <link rel="mask-icon" href="/mask-icon.svg" color="#1a1a1a"/>
-        <link rel="stylesheet" href="/grapheneos.css?14"/>
+        <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+        <link rel="stylesheet" href="https://code.getmdl.io/1.3.0/material.indigo-pink.min.css">
+        <link rel="stylesheet" href="./grapheneos.css?14"/>
         <link rel="manifest" href="/manifest.webmanifest"/>
         <link rel="canonical" href="https://grapheneos.org/"/>
     </head>
@@ -28,14 +30,14 @@
         <nav>
             <ul>
                 <li class="active"><a href="/">GrapheneOS</a></li>
-                <li><a href="/install">Install</a></li>
-                <li><a href="/build">Build</a></li>
-                <li><a href="/usage">Usage</a></li>
-                <li><a href="/faq">FAQ</a></li>
-                <li><a href="/releases">Releases</a></li>
-                <li><a href="/source">Source</a></li>
-                <li><a href="/donate">Donate</a></li>
-                <li><a href="/contact">Contact</a></li>
+                <li><a href="./install">Install</a></li>
+                <li><a href="./build">Build</a></li>
+                <li><a href="./usage">Usage</a></li>
+                <li><a href="./faq">FAQ</a></li>
+                <li><a href="./releases">Releases</a></li>
+                <li><a href="./source">Source</a></li>
+                <li><a href="./donate">Donate</a></li>
+                <li><a href="./contact">Contact</a></li>
             </ul>
         </nav>
         <div id="content">

--- a/static/index.html
+++ b/static/index.html
@@ -22,7 +22,7 @@
         <link rel="mask-icon" href="/mask-icon.svg" color="#1a1a1a"/>
         <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
         <link rel="stylesheet" href="https://code.getmdl.io/1.3.0/material.indigo-pink.min.css">
-        <link rel="stylesheet" href="./grapheneos.css?14"/>
+        <link rel="stylesheet" href="/grapheneos.css?14"/>
         <link rel="manifest" href="/manifest.webmanifest"/>
         <link rel="canonical" href="https://grapheneos.org/"/>
     </head>
@@ -30,14 +30,14 @@
         <nav>
             <ul>
                 <li class="active"><a href="/" class="first">GrapheneOS</a></li>
-                <li><a href="./install.html">Install</a></li>
-                <li><a href="./build.html">Build</a></li>
-                <li><a href="./usage.html">Usage</a></li>
-                <li><a href="./faq.html">FAQ</a></li>
-                <li><a href="./releases.html">Releases</a></li>
-                <li><a href="./source.html">Source</a></li>
-                <li><a href="./donate.html">Donate</a></li>
-                <li><a href="./contact.html">Contact</a></li>
+                <li><a href="/install">Install</a></li>
+                <li><a href="/build">Build</a></li>
+                <li><a href="/usage">Usage</a></li>
+                <li><a href="/faq">FAQ</a></li>
+                <li><a href="/releases">Releases</a></li>
+                <li><a href="/source">Source</a></li>
+                <li><a href="/donate">Donate</a></li>
+                <li><a href="/contact">Contact</a></li>
             </ul>
         </nav>
         <div id="content">

--- a/static/install.html
+++ b/static/install.html
@@ -2,40 +2,42 @@
 <html lang="en" prefix="og: http://ogp.me/ns#">
     <head>
         <meta charset="utf-8"/>
-        <title>Install | GrapheneOS</title>
-        <meta name="description" content="Installation instructions for GrapheneOS, a security and privacy focused mobile OS with Android app compatibility."/>
+        <title>GrapheneOS</title>
+        <meta name="description" content="GrapheneOS is a security and privacy focused mobile OS with Android app compatibility."/>
         <meta name="theme-color" content="#212121"/>
         <meta name="msapplication-TileColor" content="#ffffff"/>
         <meta name="viewport" content="width=device-width, initial-scale=1"/>
         <meta name="twitter:site" content="@GrapheneOS"/>
         <meta name="twitter:creator" content="@GrapheneOS"/>
-        <meta property="og:title" content="GrapheneOS install documentation"/>
-        <meta property="og:description" content="Installation instructions for GrapheneOS, a security and privacy focused mobile OS with Android app compatibility."/>
+        <meta property="og:title" content="GrapheneOS"/>
+        <meta property="og:description" content="GrapheneOS is a security and privacy focused mobile OS with Android app compatibility."/>
         <meta property="og:type" content="website"/>
         <meta property="og:image" content="https://grapheneos.org/opengraph.png"/>
         <meta property="og:image:width" content="512"/>
         <meta property="og:image:height" content="512"/>
         <meta property="og:image:alt" content="GrapheneOS logo"/>
-        <meta property="og:url" content="https://grapheneos.org/install"/>
+        <meta property="og:url" content="https://grapheneos.org/"/>
         <meta property="og:site_name" content="GrapheneOS"/>
         <link rel="icon" type="image/vnd.microsoft.icon" href="/favicon.ico"/>
         <link rel="mask-icon" href="/mask-icon.svg" color="#1a1a1a"/>
-        <link rel="stylesheet" href="/grapheneos.css?14"/>
+        <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+        <link rel="stylesheet" href="https://code.getmdl.io/1.3.0/material.indigo-pink.min.css">
+        <link rel="stylesheet" href="./grapheneos.css?14"/>
         <link rel="manifest" href="/manifest.webmanifest"/>
-        <link rel="canonical" href="https://grapheneos.org/install"/>
+        <link rel="canonical" href="https://grapheneos.org/"/>
     </head>
     <body>
         <nav>
             <ul>
-                <li><a href="/">GrapheneOS</a></li>
-                <li class="active"><a href="/install">Install</a></li>
-                <li><a href="/build">Build</a></li>
-                <li><a href="/usage">Usage</a></li>
-                <li><a href="/faq">FAQ</a></li>
-                <li><a href="/releases">Releases</a></li>
-                <li><a href="/source">Source</a></li>
-                <li><a href="/donate">Donate</a></li>
-                <li><a href="/contact">Contact</a></li>
+                <li class="active"><a href="/">GrapheneOS</a></li>
+                <li><a href="./install.html">Install</a></li>
+                <li><a href="./build.html">Build</a></li>
+                <li><a href="./usage.html">Usage</a></li>
+                <li><a href="./faq.html">FAQ</a></li>
+                <li><a href="./releases.html">Releases</a></li>
+                <li><a href="./source.html">Source</a></li>
+                <li><a href="./donate.html">Donate</a></li>
+                <li><a href="./contact.html">Contact</a></li>
             </ul>
         </nav>
         <div id="content">

--- a/static/install.html
+++ b/static/install.html
@@ -29,8 +29,8 @@
     <body>
         <nav>
             <ul>
-                <li class="active"><a href="/">GrapheneOS</a></li>
-                <li><a href="./install.html">Install</a></li>
+                <li><a href="/">GrapheneOS</a></li>
+                <li class="active"><a href="./install.html">Install</a></li>
                 <li><a href="./build.html">Build</a></li>
                 <li><a href="./usage.html">Usage</a></li>
                 <li><a href="./faq.html">FAQ</a></li>

--- a/static/install.html
+++ b/static/install.html
@@ -29,7 +29,7 @@
     <body>
         <nav>
             <ul>
-                <li><a href="/">GrapheneOS</a></li>
+                <li><a href="/" class="first">GrapheneOS</a></li>
                 <li class="active"><a href="./install.html">Install</a></li>
                 <li><a href="./build.html">Build</a></li>
                 <li><a href="./usage.html">Usage</a></li>

--- a/static/install.html
+++ b/static/install.html
@@ -29,8 +29,8 @@
     <body>
         <nav>
             <ul>
-                <li class="first"><a href="/">GrapheneOS</a></li>
-                <li><a href="./install.html" class="active">Install</a></li>
+                <li><a href="/">GrapheneOS</a></li>
+                <li class="active"><a href="./install.html">Install</a></li>
                 <li><a href="./build.html">Build</a></li>
                 <li><a href="./usage.html">Usage</a></li>
                 <li><a href="./faq.html">FAQ</a></li>

--- a/static/install.html
+++ b/static/install.html
@@ -22,7 +22,7 @@
         <link rel="mask-icon" href="/mask-icon.svg" color="#1a1a1a"/>
         <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
         <link rel="stylesheet" href="https://code.getmdl.io/1.3.0/material.indigo-pink.min.css">
-        <link rel="stylesheet" href="./grapheneos.css?14"/>
+        <link rel="stylesheet" href="/grapheneos.css?14"/>
         <link rel="manifest" href="/manifest.webmanifest"/>
         <link rel="canonical" href="https://grapheneos.org/"/>
     </head>
@@ -30,14 +30,14 @@
         <nav>
             <ul>
                 <li><a href="/" class="first">GrapheneOS</a></li>
-                <li class="active"><a href="./install.html">Install</a></li>
-                <li><a href="./build.html">Build</a></li>
-                <li><a href="./usage.html">Usage</a></li>
-                <li><a href="./faq.html">FAQ</a></li>
-                <li><a href="./releases.html">Releases</a></li>
-                <li><a href="./source.html">Source</a></li>
-                <li><a href="./donate.html">Donate</a></li>
-                <li><a href="./contact.html">Contact</a></li>
+                <li class="active"><a href="/install">Install</a></li>
+                <li><a href="/build">Build</a></li>
+                <li><a href="/usage">Usage</a></li>
+                <li><a href="/faq">FAQ</a></li>
+                <li><a href="/releases">Releases</a></li>
+                <li><a href="/source">Source</a></li>
+                <li><a href="/donate">Donate</a></li>
+                <li><a href="/contact">Contact</a></li>
             </ul>
         </nav>
         <div id="content">
@@ -201,11 +201,11 @@ RWQZW9NItOuQYJ86EooQBxScfclrWiieJtAO9GpnfEjKbCO/3FriLGX3</pre>
             space in a temporary directory, which defaults to <code>/tmp</code>:<p>
             <pre>unzip crosshatch-factory-2019.06.23.05.zip
 cd crosshatch-pq3a.190605.003
-./flash-all.sh</pre>
+/flash-all.sh</pre>
             <p>Use a different temporary directory if your <code>/tmp</code> doesn't have enough
             space available:</p>
             <pre>mkdir tmp
-TMPDIR="$PWD/tmp" ./flash-all.sh</pre>
+TMPDIR="$PWD/tmp" /flash-all.sh</pre>
             <p>Wait for the flashing process to complete and for the device to boot up using the
             new operating system.</p>
             <p>You should now proceed to locking the bootloader before using the device as locking

--- a/static/install.html
+++ b/static/install.html
@@ -29,8 +29,8 @@
     <body>
         <nav>
             <ul>
-                <li><a href="/">GrapheneOS</a></li>
-                <li class="active"><a href="./install.html">Install</a></li>
+                <li class="first"><a href="/">GrapheneOS</a></li>
+                <li><a href="./install.html" class="active">Install</a></li>
                 <li><a href="./build.html">Build</a></li>
                 <li><a href="./usage.html">Usage</a></li>
                 <li><a href="./faq.html">FAQ</a></li>

--- a/static/releases.html
+++ b/static/releases.html
@@ -29,12 +29,12 @@
     <body>
         <nav>
             <ul>
-                <li class="first"><a href="/">GrapheneOS</a></li>
+                <li><a href="/">GrapheneOS</a></li>
                 <li><a href="./install.html">Install</a></li>
                 <li><a href="./build.html">Build</a></li>
                 <li><a href="./usage.html">Usage</a></li>
                 <li><a href="./faq.html">FAQ</a></li>
-                <li><a href="./releases.html" class="active">Releases</a></li>
+                <li class="active"><a href="./releases.html">Releases</a></li>
                 <li><a href="./source.html">Source</a></li>
                 <li><a href="./donate.html">Donate</a></li>
                 <li><a href="./contact.html">Contact</a></li>

--- a/static/releases.html
+++ b/static/releases.html
@@ -29,7 +29,7 @@
     <body>
         <nav>
             <ul>
-                <li><a href="/">GrapheneOS</a></li>
+                <li><a href="/" class="first">GrapheneOS</a></li>
                 <li><a href="./install.html">Install</a></li>
                 <li><a href="./build.html">Build</a></li>
                 <li><a href="./usage.html">Usage</a></li>

--- a/static/releases.html
+++ b/static/releases.html
@@ -2,40 +2,42 @@
 <html lang="en" prefix="og: http://ogp.me/ns#">
     <head>
         <meta charset="utf-8"/>
-        <title>Releases | GrapheneOS</title>
-        <meta name="description" content="Official releases of GrapheneOS, a security and privacy focused mobile OS with Android app compatibility."/>
+        <title>GrapheneOS</title>
+        <meta name="description" content="GrapheneOS is a security and privacy focused mobile OS with Android app compatibility."/>
         <meta name="theme-color" content="#212121"/>
         <meta name="msapplication-TileColor" content="#ffffff"/>
         <meta name="viewport" content="width=device-width, initial-scale=1"/>
         <meta name="twitter:site" content="@GrapheneOS"/>
         <meta name="twitter:creator" content="@GrapheneOS"/>
-        <meta property="og:title" content="GrapheneOS releases"/>
-        <meta property="og:description" content="Official releases of GrapheneOS, a security and privacy focused mobile OS with Android app compatibility."/>
+        <meta property="og:title" content="GrapheneOS"/>
+        <meta property="og:description" content="GrapheneOS is a security and privacy focused mobile OS with Android app compatibility."/>
         <meta property="og:type" content="website"/>
         <meta property="og:image" content="https://grapheneos.org/opengraph.png"/>
         <meta property="og:image:width" content="512"/>
         <meta property="og:image:height" content="512"/>
         <meta property="og:image:alt" content="GrapheneOS logo"/>
-        <meta property="og:url" content="https://grapheneos.org/releases"/>
+        <meta property="og:url" content="https://grapheneos.org/"/>
         <meta property="og:site_name" content="GrapheneOS"/>
         <link rel="icon" type="image/vnd.microsoft.icon" href="/favicon.ico"/>
         <link rel="mask-icon" href="/mask-icon.svg" color="#1a1a1a"/>
-        <link rel="stylesheet" href="/grapheneos.css?14"/>
+        <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+        <link rel="stylesheet" href="https://code.getmdl.io/1.3.0/material.indigo-pink.min.css">
+        <link rel="stylesheet" href="./grapheneos.css?14"/>
         <link rel="manifest" href="/manifest.webmanifest"/>
-        <link rel="canonical" href="https://grapheneos.org/releases"/>
+        <link rel="canonical" href="https://grapheneos.org/"/>
     </head>
     <body>
         <nav>
             <ul>
-                <li><a href="/">GrapheneOS</a></li>
-                <li><a href="/install">Install</a></li>
-                <li><a href="/build">Build</a></li>
-                <li><a href="/usage">Usage</a></li>
-                <li><a href="/faq">FAQ</a></li>
-                <li class="active"><a href="/releases">Releases</a></li>
-                <li><a href="/source">Source</a></li>
-                <li><a href="/donate">Donate</a></li>
-                <li><a href="/contact">Contact</a></li>
+                <li class="active"><a href="/">GrapheneOS</a></li>
+                <li><a href="./install.html">Install</a></li>
+                <li><a href="./build.html">Build</a></li>
+                <li><a href="./usage.html">Usage</a></li>
+                <li><a href="./faq.html">FAQ</a></li>
+                <li><a href="./releases.html">Releases</a></li>
+                <li><a href="./source.html">Source</a></li>
+                <li><a href="./donate.html">Donate</a></li>
+                <li><a href="./contact.html">Contact</a></li>
             </ul>
         </nav>
         <div id="content">

--- a/static/releases.html
+++ b/static/releases.html
@@ -29,12 +29,12 @@
     <body>
         <nav>
             <ul>
-                <li><a href="/">GrapheneOS</a></li>
+                <li class="first"><a href="/">GrapheneOS</a></li>
                 <li><a href="./install.html">Install</a></li>
                 <li><a href="./build.html">Build</a></li>
                 <li><a href="./usage.html">Usage</a></li>
                 <li><a href="./faq.html">FAQ</a></li>
-                <li class="active"><a href="./releases.html">Releases</a></li>
+                <li><a href="./releases.html" class="active">Releases</a></li>
                 <li><a href="./source.html">Source</a></li>
                 <li><a href="./donate.html">Donate</a></li>
                 <li><a href="./contact.html">Contact</a></li>

--- a/static/releases.html
+++ b/static/releases.html
@@ -22,7 +22,7 @@
         <link rel="mask-icon" href="/mask-icon.svg" color="#1a1a1a"/>
         <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
         <link rel="stylesheet" href="https://code.getmdl.io/1.3.0/material.indigo-pink.min.css">
-        <link rel="stylesheet" href="./grapheneos.css?14"/>
+        <link rel="stylesheet" href="/grapheneos.css?14"/>
         <link rel="manifest" href="/manifest.webmanifest"/>
         <link rel="canonical" href="https://grapheneos.org/"/>
     </head>
@@ -30,14 +30,14 @@
         <nav>
             <ul>
                 <li><a href="/" class="first">GrapheneOS</a></li>
-                <li><a href="./install.html">Install</a></li>
-                <li><a href="./build.html">Build</a></li>
-                <li><a href="./usage.html">Usage</a></li>
-                <li><a href="./faq.html">FAQ</a></li>
-                <li class="active"><a href="./releases.html">Releases</a></li>
-                <li><a href="./source.html">Source</a></li>
-                <li><a href="./donate.html">Donate</a></li>
-                <li><a href="./contact.html">Contact</a></li>
+                <li><a href="/install">Install</a></li>
+                <li><a href="/build">Build</a></li>
+                <li><a href="/usage">Usage</a></li>
+                <li><a href="/faq">FAQ</a></li>
+                <li class="active"><a href="/releases">Releases</a></li>
+                <li><a href="/source">Source</a></li>
+                <li><a href="/donate">Donate</a></li>
+                <li><a href="/contact">Contact</a></li>
             </ul>
         </nav>
         <div id="content">

--- a/static/releases.html
+++ b/static/releases.html
@@ -29,12 +29,12 @@
     <body>
         <nav>
             <ul>
-                <li class="active"><a href="/">GrapheneOS</a></li>
+                <li><a href="/">GrapheneOS</a></li>
                 <li><a href="./install.html">Install</a></li>
                 <li><a href="./build.html">Build</a></li>
                 <li><a href="./usage.html">Usage</a></li>
                 <li><a href="./faq.html">FAQ</a></li>
-                <li><a href="./releases.html">Releases</a></li>
+                <li class="active"><a href="./releases.html">Releases</a></li>
                 <li><a href="./source.html">Source</a></li>
                 <li><a href="./donate.html">Donate</a></li>
                 <li><a href="./contact.html">Contact</a></li>

--- a/static/source.html
+++ b/static/source.html
@@ -29,13 +29,13 @@
     <body>
         <nav>
             <ul>
-                <li><a href="/">GrapheneOS</a></li>
+                <li class="first"><a href="/">GrapheneOS</a></li>
                 <li><a href="./install.html">Install</a></li>
                 <li><a href="./build.html">Build</a></li>
                 <li><a href="./usage.html">Usage</a></li>
                 <li><a href="./faq.html">FAQ</a></li>
                 <li><a href="./releases.html">Releases</a></li>
-                <li class="active"><a href="./source.html">Source</a></li>
+                <li><a href="./source.html" class="active">Source</a></li>
                 <li><a href="./donate.html">Donate</a></li>
                 <li><a href="./contact.html">Contact</a></li>
             </ul>

--- a/static/source.html
+++ b/static/source.html
@@ -29,13 +29,13 @@
     <body>
         <nav>
             <ul>
-                <li class="active"><a href="/">GrapheneOS</a></li>
+                <li><a href="/">GrapheneOS</a></li>
                 <li><a href="./install.html">Install</a></li>
                 <li><a href="./build.html">Build</a></li>
                 <li><a href="./usage.html">Usage</a></li>
                 <li><a href="./faq.html">FAQ</a></li>
                 <li><a href="./releases.html">Releases</a></li>
-                <li><a href="./source.html">Source</a></li>
+                <li class="active"><a href="./source.html">Source</a></li>
                 <li><a href="./donate.html">Donate</a></li>
                 <li><a href="./contact.html">Contact</a></li>
             </ul>

--- a/static/source.html
+++ b/static/source.html
@@ -22,7 +22,7 @@
         <link rel="mask-icon" href="/mask-icon.svg" color="#1a1a1a"/>
         <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
         <link rel="stylesheet" href="https://code.getmdl.io/1.3.0/material.indigo-pink.min.css">
-        <link rel="stylesheet" href="./grapheneos.css?14"/>
+        <link rel="stylesheet" href="/grapheneos.css?14"/>
         <link rel="manifest" href="/manifest.webmanifest"/>
         <link rel="canonical" href="https://grapheneos.org/"/>
     </head>
@@ -30,14 +30,14 @@
         <nav>
             <ul>
                 <li><a href="/" class="first">GrapheneOS</a></li>
-                <li><a href="./install.html">Install</a></li>
-                <li><a href="./build.html">Build</a></li>
-                <li><a href="./usage.html">Usage</a></li>
-                <li><a href="./faq.html">FAQ</a></li>
-                <li><a href="./releases.html">Releases</a></li>
-                <li class="active"><a href="./source.html">Source</a></li>
-                <li><a href="./donate.html">Donate</a></li>
-                <li><a href="./contact.html">Contact</a></li>
+                <li><a href="/install">Install</a></li>
+                <li><a href="/build">Build</a></li>
+                <li><a href="/usage">Usage</a></li>
+                <li><a href="/faq">FAQ</a></li>
+                <li><a href="/releases">Releases</a></li>
+                <li class="active"><a href="/source">Source</a></li>
+                <li><a href="/donate">Donate</a></li>
+                <li><a href="/contact">Contact</a></li>
             </ul>
         </nav>
         <div id="content">

--- a/static/source.html
+++ b/static/source.html
@@ -29,13 +29,13 @@
     <body>
         <nav>
             <ul>
-                <li class="first"><a href="/">GrapheneOS</a></li>
+                <li><a href="/">GrapheneOS</a></li>
                 <li><a href="./install.html">Install</a></li>
                 <li><a href="./build.html">Build</a></li>
                 <li><a href="./usage.html">Usage</a></li>
                 <li><a href="./faq.html">FAQ</a></li>
                 <li><a href="./releases.html">Releases</a></li>
-                <li><a href="./source.html" class="active">Source</a></li>
+                <li class="active"><a href="./source.html">Source</a></li>
                 <li><a href="./donate.html">Donate</a></li>
                 <li><a href="./contact.html">Contact</a></li>
             </ul>

--- a/static/source.html
+++ b/static/source.html
@@ -29,7 +29,7 @@
     <body>
         <nav>
             <ul>
-                <li><a href="/">GrapheneOS</a></li>
+                <li><a href="/" class="first">GrapheneOS</a></li>
                 <li><a href="./install.html">Install</a></li>
                 <li><a href="./build.html">Build</a></li>
                 <li><a href="./usage.html">Usage</a></li>

--- a/static/source.html
+++ b/static/source.html
@@ -2,40 +2,42 @@
 <html lang="en" prefix="og: http://ogp.me/ns#">
     <head>
         <meta charset="utf-8"/>
-        <title>Source | GrapheneOS</title>
-        <meta name="description" content="Source code for GrapheneOS."/>
+        <title>GrapheneOS</title>
+        <meta name="description" content="GrapheneOS is a security and privacy focused mobile OS with Android app compatibility."/>
         <meta name="theme-color" content="#212121"/>
         <meta name="msapplication-TileColor" content="#ffffff"/>
         <meta name="viewport" content="width=device-width, initial-scale=1"/>
         <meta name="twitter:site" content="@GrapheneOS"/>
         <meta name="twitter:creator" content="@GrapheneOS"/>
-        <meta property="og:title" content="GrapheneOS source"/>
-        <meta property="og:description" content="Source code for GrapheneOS."/>
+        <meta property="og:title" content="GrapheneOS"/>
+        <meta property="og:description" content="GrapheneOS is a security and privacy focused mobile OS with Android app compatibility."/>
         <meta property="og:type" content="website"/>
         <meta property="og:image" content="https://grapheneos.org/opengraph.png"/>
         <meta property="og:image:width" content="512"/>
         <meta property="og:image:height" content="512"/>
         <meta property="og:image:alt" content="GrapheneOS logo"/>
-        <meta property="og:url" content="https://grapheneos.org/source"/>
+        <meta property="og:url" content="https://grapheneos.org/"/>
         <meta property="og:site_name" content="GrapheneOS"/>
         <link rel="icon" type="image/vnd.microsoft.icon" href="/favicon.ico"/>
         <link rel="mask-icon" href="/mask-icon.svg" color="#1a1a1a"/>
-        <link rel="stylesheet" href="/grapheneos.css?14"/>
+        <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+        <link rel="stylesheet" href="https://code.getmdl.io/1.3.0/material.indigo-pink.min.css">
+        <link rel="stylesheet" href="./grapheneos.css?14"/>
         <link rel="manifest" href="/manifest.webmanifest"/>
-        <link rel="canonical" href="https://grapheneos.org/source"/>
+        <link rel="canonical" href="https://grapheneos.org/"/>
     </head>
     <body>
         <nav>
             <ul>
-                <li><a href="/">GrapheneOS</a></li>
-                <li><a href="/install">Install</a></li>
-                <li><a href="/build">Build</a></li>
-                <li><a href="/usage">Usage</a></li>
-                <li><a href="/faq">FAQ</a></li>
-                <li><a href="/releases">Releases</a></li>
-                <li class="active"><a href="/source">Source</a></li>
-                <li><a href="/donate">Donate</a></li>
-                <li><a href="/contact">Contact</a></li>
+                <li class="active"><a href="/">GrapheneOS</a></li>
+                <li><a href="./install.html">Install</a></li>
+                <li><a href="./build.html">Build</a></li>
+                <li><a href="./usage.html">Usage</a></li>
+                <li><a href="./faq.html">FAQ</a></li>
+                <li><a href="./releases.html">Releases</a></li>
+                <li><a href="./source.html">Source</a></li>
+                <li><a href="./donate.html">Donate</a></li>
+                <li><a href="./contact.html">Contact</a></li>
             </ul>
         </nav>
         <div id="content">

--- a/static/usage.html
+++ b/static/usage.html
@@ -22,7 +22,7 @@
         <link rel="mask-icon" href="/mask-icon.svg" color="#1a1a1a"/>
         <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
         <link rel="stylesheet" href="https://code.getmdl.io/1.3.0/material.indigo-pink.min.css">
-        <link rel="stylesheet" href="./grapheneos.css?14"/>
+        <link rel="stylesheet" href="/grapheneos.css?14"/>
         <link rel="manifest" href="/manifest.webmanifest"/>
         <link rel="canonical" href="https://grapheneos.org/"/>
     </head>
@@ -30,14 +30,14 @@
         <nav>
             <ul>
                 <li><a href="/" class="first">GrapheneOS</a></li>
-                <li><a href="./install.html">Install</a></li>
-                <li><a href="./build.html">Build</a></li>
-                <li class="active"><a href="./usage.html">Usage</a></li>
-                <li><a href="./faq.html">FAQ</a></li>
-                <li><a href="./releases.html">Releases</a></li>
-                <li><a href="./source.html">Source</a></li>
-                <li><a href="./donate.html">Donate</a></li>
-                <li><a href="./contact.html">Contact</a></li>
+                <li><a href="/install">Install</a></li>
+                <li><a href="/build">Build</a></li>
+                <li class="active"><a href="/usage">Usage</a></li>
+                <li><a href="/faq">FAQ</a></li>
+                <li><a href="/releases">Releases</a></li>
+                <li><a href="/source">Source</a></li>
+                <li><a href="/donate">Donate</a></li>
+                <li><a href="/contact">Contact</a></li>
             </ul>
         </nav>
         <div id="content">

--- a/static/usage.html
+++ b/static/usage.html
@@ -29,10 +29,10 @@
     <body>
         <nav>
             <ul>
-                <li><a href="/">GrapheneOS</a></li>
+                <li class="first"><a href="/">GrapheneOS</a></li>
                 <li><a href="./install.html">Install</a></li>
                 <li><a href="./build.html">Build</a></li>
-                <li class="active"><a href="./usage.html">Usage</a></li>
+                <li><a href="./usage.html" class="active">Usage</a></li>
                 <li><a href="./faq.html">FAQ</a></li>
                 <li><a href="./releases.html">Releases</a></li>
                 <li><a href="./source.html">Source</a></li>

--- a/static/usage.html
+++ b/static/usage.html
@@ -29,10 +29,10 @@
     <body>
         <nav>
             <ul>
-                <li class="first"><a href="/">GrapheneOS</a></li>
+                <li><a href="/">GrapheneOS</a></li>
                 <li><a href="./install.html">Install</a></li>
                 <li><a href="./build.html">Build</a></li>
-                <li><a href="./usage.html" class="active">Usage</a></li>
+                <li class="active"><a href="./usage.html">Usage</a></li>
                 <li><a href="./faq.html">FAQ</a></li>
                 <li><a href="./releases.html">Releases</a></li>
                 <li><a href="./source.html">Source</a></li>

--- a/static/usage.html
+++ b/static/usage.html
@@ -29,7 +29,7 @@
     <body>
         <nav>
             <ul>
-                <li><a href="/">GrapheneOS</a></li>
+                <li><a href="/" class="first">GrapheneOS</a></li>
                 <li><a href="./install.html">Install</a></li>
                 <li><a href="./build.html">Build</a></li>
                 <li class="active"><a href="./usage.html">Usage</a></li>

--- a/static/usage.html
+++ b/static/usage.html
@@ -2,40 +2,42 @@
 <html lang="en" prefix="og: http://ogp.me/ns#">
     <head>
         <meta charset="utf-8"/>
-        <title>Usage | GrapheneOS</title>
-        <meta name="description" content="Usage instructions for GrapheneOS, a security and privacy focused mobile OS with Android app compatibility."/>
+        <title>GrapheneOS</title>
+        <meta name="description" content="GrapheneOS is a security and privacy focused mobile OS with Android app compatibility."/>
         <meta name="theme-color" content="#212121"/>
         <meta name="msapplication-TileColor" content="#ffffff"/>
         <meta name="viewport" content="width=device-width, initial-scale=1"/>
         <meta name="twitter:site" content="@GrapheneOS"/>
         <meta name="twitter:creator" content="@GrapheneOS"/>
-        <meta property="og:title" content="GrapheneOS usage documentation"/>
-        <meta property="og:description" content="Usage instructions for GrapheneOS, a security and privacy focused mobile OS with Android app compatibility."/>
+        <meta property="og:title" content="GrapheneOS"/>
+        <meta property="og:description" content="GrapheneOS is a security and privacy focused mobile OS with Android app compatibility."/>
         <meta property="og:type" content="website"/>
         <meta property="og:image" content="https://grapheneos.org/opengraph.png"/>
         <meta property="og:image:width" content="512"/>
         <meta property="og:image:height" content="512"/>
         <meta property="og:image:alt" content="GrapheneOS logo"/>
-        <meta property="og:url" content="https://grapheneos.org/usage"/>
+        <meta property="og:url" content="https://grapheneos.org/"/>
         <meta property="og:site_name" content="GrapheneOS"/>
         <link rel="icon" type="image/vnd.microsoft.icon" href="/favicon.ico"/>
         <link rel="mask-icon" href="/mask-icon.svg" color="#1a1a1a"/>
-        <link rel="stylesheet" href="/grapheneos.css?14"/>
+        <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+        <link rel="stylesheet" href="https://code.getmdl.io/1.3.0/material.indigo-pink.min.css">
+        <link rel="stylesheet" href="./grapheneos.css?14"/>
         <link rel="manifest" href="/manifest.webmanifest"/>
-        <link rel="canonical" href="https://grapheneos.org/usage"/>
+        <link rel="canonical" href="https://grapheneos.org/"/>
     </head>
     <body>
         <nav>
             <ul>
-                <li><a href="/">GrapheneOS</a></li>
-                <li><a href="/install">Install</a></li>
-                <li><a href="/build">Build</a></li>
-                <li class="active"><a href="/usage">Usage</a></li>
-                <li><a href="/faq">FAQ</a></li>
-                <li><a href="/releases">Releases</a></li>
-                <li><a href="/source">Source</a></li>
-                <li><a href="/donate">Donate</a></li>
-                <li><a href="/contact">Contact</a></li>
+                <li class="active"><a href="/">GrapheneOS</a></li>
+                <li><a href="./install.html">Install</a></li>
+                <li><a href="./build.html">Build</a></li>
+                <li><a href="./usage.html">Usage</a></li>
+                <li><a href="./faq.html">FAQ</a></li>
+                <li><a href="./releases.html">Releases</a></li>
+                <li><a href="./source.html">Source</a></li>
+                <li><a href="./donate.html">Donate</a></li>
+                <li><a href="./contact.html">Contact</a></li>
             </ul>
         </nav>
         <div id="content">

--- a/static/usage.html
+++ b/static/usage.html
@@ -29,10 +29,10 @@
     <body>
         <nav>
             <ul>
-                <li class="active"><a href="/">GrapheneOS</a></li>
+                <li><a href="/">GrapheneOS</a></li>
                 <li><a href="./install.html">Install</a></li>
                 <li><a href="./build.html">Build</a></li>
-                <li><a href="./usage.html">Usage</a></li>
+                <li class="active"><a href="./usage.html">Usage</a></li>
                 <li><a href="./faq.html">FAQ</a></li>
                 <li><a href="./releases.html">Releases</a></li>
                 <li><a href="./source.html">Source</a></li>


### PR DESCRIPTION
Updated grapheneos.org design using material lite. Minimal changes done to actual structure and content of the website. Example of new design can be seen below

[Example 1](https://i.imgur.com/3y7S135.png)
[Example 2](https://i.imgur.com/58e1HUg.png)
[Example 3](https://i.imgur.com/VApiArO.png)