### PR TITLE
use h3 for Wi-Fi subsections

### DIFF
--- a/static/usage.html
+++ b/static/usage.html
@@ -345,9 +345,9 @@
             documented (see the FAQ) and can be easily disabled or forced through a VPN
             service.</p>
 
-            <h2 id="wifi-privacy-scanning">
+            <h3 id="wifi-privacy-scanning">
                 <a href="#wifi-privacy-scanning">Scanning</a>
-            </h2>
+            </h3>
 
             <p>MAC randomization is always performed for Wi-Fi scanning. Pixel
             phones have firmware support for scanning MAC randomization going
@@ -371,9 +371,9 @@
             The initial focus will likely be a cell phone tower database, so these features still
             wouldn't be relevant.</p>
 
-            <h2 id="wifi-privacy-associated">
+            <h3 id="wifi-privacy-associated">
                 <a href="#wifi-privacy-associated">Associated with an Access Point (AP)</a>
-            </h2>
+            </h3>
 
             <p>The DHCP client uses the anonymity profile rather than sending a hostname so it
             doesn't compromise the privacy offered by MAC randomization.</p>


### PR DESCRIPTION
The table of contents lists them as subsections, so they should use h3
instead of h2.