### PR TITLE
add repo package information to build page

### DIFF
--- a/static/build.html
+++ b/static/build.html
@@ -218,7 +218,9 @@
             development. Older branches are no longer maintained. It is currently used for all
             officially supported devices and should be used for the basis of ports to other
             devices. Occasionally, some devices may be supported through device support branches
-            to avoid impacting other devices with changes needed to support them.</p>
+            to avoid impacting other devices with changes needed to support them. Before continuing
+            make sure to download repo package from your distribution. To check if you have repo installed
+            run <code>which repo</code>in your terminal.</p>
 
             <pre>mkdir grapheneos-10
 cd grapheneos-10


### PR DESCRIPTION
I think adding how to get a package will help new developers and testers avoid unnecessary roadblocks. I would appreciate any feedback to make this request better.