### PR TITLE
add GitHub workflow for validate_static

### DIFF
--- a/.github/workflows/validate-static.yml
+++ b/.github/workflows/validate-static.yml
@@ -1,0 +1,47 @@
+name: Validate static
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+jobs:
+  validate-static:
+    runs-on: ubuntu-latest
+    
+    env:
+      VALIDATOR_VERSION: 20.3.16
+    
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+    
+    - name: Cache node modules
+      uses: actions/cache@v1
+      env:
+        cache-name: cache-node-modules
+      with:
+        path: ~/.npm 
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+
+    - name: Cache validator
+      id: validator-cache
+      uses: actions/cache@v1
+      with:
+        path: vnu-runtime-image
+        key: ${{ runner.os }}-validator-${{ env.VALIDATOR_VERSION }}
+
+    - run: sudo apt-get -y install libxml2-utils
+    - run: npm install
+
+    - name: Download validatornu
+      # There isn't a package with a `validatornu` command in Ubuntu, so download the validator
+      # from the GitHub releases and change the validate_static script later to use it.
+      run: wget https://github.com/validator/validator/releases/download/${{ env.VALIDATOR_VERSION }}/vnu.linux.zip && unzip vnu.linux.zip
+      if: steps.validator-cache.outputs.cache-hit != 'true'
+
+    - run: sed -i 's+validatornu+vnu-runtime-image/bin/vnu+g' validate_static
+
+    - name: validate static
+      run: ./validate_static
+


### PR DESCRIPTION
Uses a GitHub-hosted runner in order to run `validate_static` for all pull requests and pushes to master. See https://help.github.com/en/actions/getting-started-with-github-actions/about-github-actions for more details. (Linux GitHub-hosted runners are limited to Ubuntu.)

This could be helpful to validate `static` for contributor pull requests to save some time. GitHub Actions usage is also free for public repositories.

Since Ubuntu doesn't seem to have a package with `validatornu`, the workflow downloads validator directly from [GitHub releases](https://github.com/validator/validator/releases), unzips it to use the pre-compiled Linux binary, and then replaces `validatornu` in the script with the relative path to the binary.

Dependencies are [cached](https://help.github.com/en/actions/configuring-and-managing-workflows/caching-dependencies-to-speed-up-workflows) to speed up validation.

To see it in action:

![pr-checks](https://user-images.githubusercontent.com/26474149/80946530-17667e00-8da3-11ea-8b55-374372711322.png)

(example repo deleted now that this has been merged)

It seems that in the repository settings, "Enable local and third party Actions for this repository" would need to be selected, since the checkout, node, and caching actions are considered third party.