### PR TITLE
fix Windows command type and clarify expected result / steps after

### DIFF
--- a/static/install.html
+++ b/static/install.html
@@ -279,17 +279,14 @@ cd crosshatch-qq2a.200405.005</pre>
 
             <p>Wait for the flashing process to complete (message about not formatting 'userdata' 
             and 'metadata' can be expected).</p>
-            
+
             <p>On current generation devices like the Pixel 3, Pixel 3 XL, Pixel 3a and Pixel 3a
             XL the script ends with the fastbootd menu on the phone. On other devices it might 
             boot the OS. From the fastbootd menu choose Reboot to bootloader. In case the OS 
             booted, shutdown and boot in bootloader using Volume Down + Power.</p>
 
-            <p>Re-lock the bootloader before using the device as locking wipes the data again:</p>
-
-            <pre>fastboot flashing lock</pre>
-
-            <p>The command needs to be confirmed on the device.</p>
+            <p>Re-lock the bootloader (using instructions below) before using the device (as 
+            locking wipes the data again).</p>
 
             <h3 id="troubleshooting">
                 <a href="#troubleshooting">Troubleshooting</a>

--- a/static/install.html
+++ b/static/install.html
@@ -275,7 +275,7 @@ cd crosshatch-qq2a.200405.005</pre>
 
             <p>On Windows:</p>
 
-            <pre>flash-all</pre>
+            <pre>./flash-all.bat</pre>
 
             <p>Wait for the flashing process to complete and for the device to boot up using the
             new operating system.</p>

--- a/static/install.html
+++ b/static/install.html
@@ -277,16 +277,19 @@ cd crosshatch-qq2a.200405.005</pre>
 
             <pre>./flash-all.bat</pre>
 
-            <p>Wait for the flashing process to complete and for the device to boot up using the
-            new operating system.</p>
-
-            <p>You should now proceed to locking the bootloader before using the device as locking
-            wipes the data again.</p>
-
+            <p>Wait for the flashing process to complete (message about not formatting 'userdata' 
+            and 'metadata' can be expected).</p>
+            
             <p>On current generation devices like the Pixel 3, Pixel 3 XL, Pixel 3a and Pixel 3a
-            XL, you'll need to reboot from the userspace fastbootd mode to the bootloader by
-            selecting <code>Reboot to bootloader</code> from the fastbootd menu using the volume
-            keys and the power button in order to continue the installation.</p>
+            XL the script ends with the fastbootd menu on the phone. On other devices it might 
+            boot the OS. From the fastbootd menu choose Reboot to bootloader. In case the OS 
+            booted, shutdown and boot in bootloader using Volume Down + Power.</p>
+
+            <p>Re-lock the bootloader before using the device as locking wipes the data again:</p>
+
+            <pre>fastboot flashing lock</pre>
+
+            <p>The command needs to be confirmed on the device.</p>
 
             <h3 id="troubleshooting">
                 <a href="#troubleshooting">Troubleshooting</a>


### PR DESCRIPTION
FIX COMMAND : otherwise PS will report "flash-all : The term 'flash-all' is not recognized as the name of a cmdlet, function, script file, or..."
CLARIFY STEPS AFTER : apparently I was able to fail to understand the meaning of the instructions until some iterations, so attempting to make it easier to understand for new users like me