### PR TITLE
update flashing factory image section

### DIFF
--- a/static/install.html
+++ b/static/install.html
@@ -318,11 +318,6 @@ curl -O https://releases.grapheneos.org/crosshatch-factory-2020.05.05.02.zip.sig
             <p>Wait for the flashing process to complete and proceed to locking the bootloader
             before using the device as locking wipes the data again.</p>
 
-            <p>On current generation devices like the Pixel 3, Pixel 3 XL, Pixel 3a and Pixel 3a
-            XL, you'll need to reboot from the userspace fastbootd mode to the bootloader by
-            selecting <code>Reboot to bootloader</code> from the fastbootd menu using the volume
-            keys and the power button in order to continue the installation.</p>
-
             <h3 id="troubleshooting">
                 <a href="#troubleshooting">Troubleshooting</a>
             </h3>


### PR DESCRIPTION
Merging GrapheneOS/device_common#4 would remove the need to manually select Reboot to bootloader after flashing completes.