### PR TITLE
List Pixel 2 (XL) for updated APNs in release notes

### DIFF
--- a/static/releases.html
+++ b/static/releases.html
@@ -393,7 +393,7 @@
                 <li>rebased onto QQ3A.200605.002 release</li>
                 <li>change TrichromeLibrary package name</li>
                 <li>drop MAC randomization preference migration code</li>
-                <li>Pixel 3, Pixel 3 XL, Pixel 3a, Pixel 3a XL, Pixel 4, Pixel 4 XL: update APNs with carriersettings-extractor</li>
+                <li>Pixel 2, Pixel 2 XL, Pixel 3, Pixel 3 XL, Pixel 3a, Pixel 3a XL, Pixel 4, Pixel 4 XL: update APNs with carriersettings-extractor</li>
                 <li>disable network time refresh when network time is disabled (previous behavior inherited from upstream)</li>
                 <li>kernel (Pixel 2, Pixel 2 XL, Pixel 3, Pixel 3 XL, Pixel 3a, Pixel 3a XL, Pixel 4, Pixel 4 XL): make reproducible builds simpler</li>
                 <li>kernel (Pixel 4, Pixel 4 XL): use max mmap entropy by default to cover init</li>


### PR DESCRIPTION
APN changes in GrapheneOS/device_google_muskie#2 and
GrapheneOS/device_google_taimen#1.