### PR TITLE
fix hyperlink text for QQ3A.200705.002

### DIFF
--- a/static/releases.html
+++ b/static/releases.html
@@ -382,7 +382,7 @@
 
             <p>Tags:</p>
             <ul>
-                <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/QQ3A.200705.002.2020.07.06.20">QQ3A.200605.001.2020.07.06.20</a> (Pixel 2, Pixel 2 XL, Pixel 3, Pixel 3 XL, Pixel 3a, Pixel 3a XL, Pixel 4, Pixel 4 XL, emulator, generic, other targets)</li>
+                <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/QQ3A.200705.002.2020.07.06.20">QQ3A.200705.002.2020.07.06.20</a> (Pixel 2, Pixel 2 XL, Pixel 3, Pixel 3 XL, Pixel 3a, Pixel 3a XL, Pixel 4, Pixel 4 XL, emulator, generic, other targets)</li>
             </ul>
 
             <p>Changes since the 2020.06.22.21 release:</p>


### PR DESCRIPTION
Also, it seems that the QQ3A.200705.002.2020.07.06.20 tag hasn't been pushed yet to https://github.com/GrapheneOS/platform_manifest/tags, so https://github.com/GrapheneOS/platform_manifest/releases/tag/QQ3A.200705.002.2020.07.06.20 currently returns a 404 error