### PR TITLE
change Play Services -> Play services

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -119,7 +119,7 @@
                 <a href="#never-google-services">No Google apps or services</a>
             </h2>
 
-            <p>GrapheneOS will never include either Google Play Services or another implementation
+            <p>GrapheneOS will never include either Google Play services or another implementation
             of Google services like microG. Those are not part of the Android Open Source Project
             and are not required for baseline Android compatibility. Apps designed to run on
             Android rather than only Android with bundled Google apps and services already work on

--- a/static/install.html
+++ b/static/install.html
@@ -228,7 +228,7 @@ Installed as /home/username/downloads/platform-tools/fastboot</pre>
 
             <p>Next, go to Settings ➔ System ➔ Advanced ➔ Developer options and toggle on the
             'Enable OEM unlocking' setting. This requires internet access on devices with Google
-            Play Services as part of Factory Reset Protection (FRP) for anti-theft protection.</p>
+            Play services as part of Factory Reset Protection (FRP) for anti-theft protection.</p>
 
             <h2 id="unlocking-the-bootloader">
                 <a href="#unlocking-the-bootloader">Unlocking the bootloader</a>

--- a/static/releases.html
+++ b/static/releases.html
@@ -690,7 +690,7 @@
                 <li>integrate <a href="https://calyxinstitute.org/projects/seedvault-encrypted-backup-for-android">Seedvault</a> backup app as the default backup service</li>
                 <li>integrate port of CalyxOS SetupWizard app to support restoring with Seedvault and other initial setup</li>
                 <li>Vanadium: disable unused safe browsing feature by default (Safe Browsing is
-                currently a no-op due to the lack of Play Services, and support for using the
+                currently a no-op due to the lack of Play services, and support for using the
                 local database backend hasn't been implemented. Various changes would be needed to
                 make it available and to make sure that privacy is preserved.)</li>
                 <li>Vanadium: disable unused Google VR support</li>
@@ -1123,7 +1123,7 @@
             <ul>
                 <li>Vanadium (browser and WebView): update Chromium base to 75.0.3770.143</li>
                 <li>Vanadium: disable media router media remoting by default</li>
-                <li>Vanadium: disable media router by default (avoids the triggering warning about not having Play Services)</li>
+                <li>Vanadium: disable media router by default (avoids the triggering warning about not having Play services)</li>
                 <li>Vanadium: remove Help &amp; feedback menu entry</li>
                 <li>Vanadium: further string rebranding from Chromium / Chrome to Vanadium</li>
                 <li>Vanadium: disable unused reporting feature at compile-time</li>


### PR DESCRIPTION
It's how Google capitalizes it (e.g. https://play.google.com/store/apps/details?id=com.google.android.gms)