### PR TITLE
Update fastboot.js for zip.js updates

### DIFF
--- a/static/js/web-install.js
+++ b/static/js/web-install.js
@@ -87,7 +87,9 @@ function addButtonHook(id, callback) {
 // zip.js is loaded separately.
 // eslint-disable-next-line no-undef
 zip.configure({
-    workerScriptsPath: "/js/fastboot/libs/",
+    workerScripts: {
+        inflate: ["/js/fastboot/libs/z-worker-pako.js", "pako_inflate.min.js"],
+    },
 });
 
 if ("usb" in navigator) {

--- a/static/web-install.html
+++ b/static/web-install.html
@@ -26,12 +26,12 @@
         <link rel="stylesheet" href="/grapheneos.css?29"/>
         <link rel="manifest" href="/manifest.webmanifest"/>
         <link rel="license" href="/LICENSE.txt"/>
-        <script defer="defer" src="/js/fastboot/libs/zip.min.js?0"></script>
-        <script type="module" src="/js/fastboot/common.js?0"></script>
-        <script type="module" src="/js/fastboot/factory.js?0"></script>
-        <script type="module" src="/js/fastboot/sparse.js?0"></script>
-        <script type="module" src="/js/fastboot/fastboot.js?0"></script>
-        <script type="module" src="/js/web-install.js?2"></script>
+        <script defer="defer" src="/js/fastboot/libs/zip-inflate.min.js?0"></script>
+        <script type="module" src="/js/fastboot/common.js?1"></script>
+        <script type="module" src="/js/fastboot/factory.js?1"></script>
+        <script type="module" src="/js/fastboot/sparse.js?1"></script>
+        <script type="module" src="/js/fastboot/fastboot.js?1"></script>
+        <script type="module" src="/js/web-install.js?3"></script>
     </head>
     <body>
         <header>

--- a/validate_static
+++ b/validate_static
@@ -14,6 +14,6 @@ for file in static_tmp/**/*.@(json|webmanifest); do
 done
 
 xmllint --noout static_tmp/**/*.@(html|svg|xml)
-eslint static_tmp/**/!(zip.min|z-worker).js
+eslint static_tmp/**/!(zip-inflate.min|z-worker-pako|pako_inflate.min).js
 stylelint static_tmp/**/*.css
 validatornu --Werror --also-check-css --also-check-svg static_tmp/**/*.@(css|html|svg)


### PR DESCRIPTION
This reduces the size of the zip.js libraries and improves flashing speed by 1.7x due to the Pako inflate implementation.