### PR TITLE
Switch to bundled fastboot.js

### DIFF
--- a/process_static
+++ b/process_static
@@ -7,7 +7,7 @@ export PATH="$PWD/node_modules/.bin:$PATH"
 
 rm -rf static_tmp
 cp -a static static_tmp
-rm -rf static_tmp/js/fastboot/{.git,demo,README.md}
+rm -rf static_tmp/js/fastboot/{!(dist),dist/!(fastboot.min.js|libs)}
 
 for file in static_tmp/**/*.@(json|webmanifest); do
     json_reformat -m < "$file" | sponge "$file"

--- a/static/js/web-install.js
+++ b/static/js/web-install.js
@@ -1,7 +1,6 @@
 // @license magnet:?xt=urn:btih:d3d9a9a6595521f9666a5e94cc830dab83b65699&dn=expat.txt MIT
 
-import { FastbootDevice } from "./fastboot/fastboot.js";
-import * as Factory from "./fastboot/factory.js";
+import { FastbootDevice, FactoryImages } from "./fastboot/dist/fastboot.min.js?0";
 
 const RELEASES_URL = "https://releases.grapheneos.org";
 
@@ -37,7 +36,7 @@ async function downloadRelease(setProgress) {
     // Download and cache the zip as a blob
     setProgress(`Downloading ${releaseId} release for ${product}...`);
     lastReleaseZip = `${product}-factory-${releaseId}.zip`;
-    await Factory.downloadZip(`${RELEASES_URL}/${lastReleaseZip}`);
+    await FactoryImages.downloadZip(`${RELEASES_URL}/${lastReleaseZip}`);
     return `Downloaded ${releaseId} release for ${product}.`;
 }
 
@@ -45,7 +44,7 @@ async function flashRelease(setProgress) {
     await ensureConnected(setProgress);
 
     setProgress("Flashing release...");
-    await Factory.flashZip(device, lastReleaseZip, (action, partition) => {
+    await FactoryImages.flashZip(device, lastReleaseZip, (action, partition) => {
         let userPartition = partition == "avb_custom_key" ? "verified boot key" : partition;
         if (action == "unpack") {
             setProgress(`Unpacking image: ${userPartition}`);
@@ -84,11 +83,9 @@ function addButtonHook(id, callback) {
     };
 }
 
-// zip.js is loaded separately.
-// eslint-disable-next-line no-undef
-zip.configure({
+FactoryImages.configureZip({
     workerScripts: {
-        inflate: ["/js/fastboot/libs/z-worker-pako.js", "pako_inflate.min.js"],
+        inflate: ["/js/fastboot/dist/libs/z-worker-pako.js", "pako_inflate.min.js"],
     },
 });
 

--- a/static/web-install.html
+++ b/static/web-install.html
@@ -26,12 +26,8 @@
         <link rel="stylesheet" href="/grapheneos.css?29"/>
         <link rel="manifest" href="/manifest.webmanifest"/>
         <link rel="license" href="/LICENSE.txt"/>
-        <script defer="defer" src="/js/fastboot/libs/zip-inflate.min.js?0"></script>
-        <script type="module" src="/js/fastboot/common.js?1"></script>
-        <script type="module" src="/js/fastboot/factory.js?1"></script>
-        <script type="module" src="/js/fastboot/sparse.js?1"></script>
-        <script type="module" src="/js/fastboot/fastboot.js?1"></script>
-        <script type="module" src="/js/web-install.js?3"></script>
+        <script type="module" src="/js/fastboot/dist/fastboot.min.js?0"></script>
+        <script type="module" src="/js/web-install.js?4"></script>
     </head>
     <body>
         <header>

--- a/validate_static
+++ b/validate_static
@@ -14,6 +14,6 @@ for file in static_tmp/**/*.@(json|webmanifest); do
 done
 
 xmllint --noout static_tmp/**/*.@(html|svg|xml)
-eslint static_tmp/**/!(zip-inflate.min|z-worker-pako|pako_inflate.min).js
+eslint static_tmp/**/!(fastboot.min|z-worker-pako|pako_inflate.min).js
 stylelint static_tmp/**/*.css
 validatornu --Werror --also-check-css --also-check-svg static_tmp/**/*.@(css|html|svg)


### PR DESCRIPTION
This simplifies cache busting greatly without needing to do further processing on any fastboot.js code before deploying. It also removes the need for a non-module script with global scope.