### PR TITLE
Update fastboot.js for AVB key flashing fix

### DIFF
--- a/static/install/web.html
+++ b/static/install/web.html
@@ -27,7 +27,7 @@
         <link rel="manifest" href="/manifest.webmanifest"/>
         <link rel="license" href="/LICENSE.txt"/>
         <script type="module" src="/js/redirect.js?9"></script>
-        <script type="module" src="/js/fastboot/dist/fastboot.min.mjs?0"></script>
+        <script type="module" src="/js/fastboot/dist/fastboot.min.mjs?1"></script>
         <script type="module" src="/js/web-install.js?5"></script>
     </head>
     <body>

--- a/static/js/web-install.js
+++ b/static/js/web-install.js
@@ -1,6 +1,6 @@
 // @license magnet:?xt=urn:btih:d3d9a9a6595521f9666a5e94cc830dab83b65699&dn=expat.txt MIT
 
-import * as fastboot from "./fastboot/dist/fastboot.min.mjs?0";
+import * as fastboot from "./fastboot/dist/fastboot.min.mjs?1";
 
 const RELEASES_URL = "https://releases.grapheneos.org";
 


### PR DESCRIPTION
Custom AVB key flashing was broken after the last update due to android-info.txt requirement checks.