### PR TITLE
Replace inappropriate hyphens

### DIFF
--- a/static/features.html
+++ b/static/features.html
@@ -122,7 +122,7 @@
                     as an improvement over Android's default per-network MAC randomization reusing
                     the same MAC address until the DHCP lease with that network expires (can still
                     use the standard implementation or fully disable it)</li>
-                    <li>Vanadium: hardened WebView and default browser - the WebView is what most
+                    <li>Vanadium: hardened WebView and default browser — the WebView is what most
                     other apps use to handle web content, so you benefit from Vanadium in many apps
                     even if you choose another browser</li>
                     <li>Hardware-based security verification and monitoring: the
@@ -179,7 +179,7 @@
                     <li>Strict privacy and security practices for our infrastructure</li>
                     <li>Unnecessary logging is avoided and logs are automatically purged after 10 days</li>
                     <li>Services hosted on OVH without involving any additional parties for CDNs,
-                    mirrors or other services - we don't outsource to others</li>
+                    mirrors or other services. We don't outsource to others</li>
                     <li>Our services are built with open technology stacks to avoid being locked in to
                     any particular hosting provider or vendor</li>
                     <li>Open documentation on our infrastructure including listing out all of our

--- a/static/releases.html
+++ b/static/releases.html
@@ -431,7 +431,7 @@
                         <li>SetupWizard: change OS name to GrapheneOS for backup activity strings again</li>
                         <li>fix use-after-free in adbd authentication which was breaking support for persistently trusting keys due to zero-on-free</li>
                         <li>device theme: use blue accent color</li>
-                        <li>replace default AOSP wallpaper with a solid black wallpaper - may get a bit fancier in the near future</li>
+                        <li>replace default AOSP wallpaper with a solid black wallpaper — may get a bit fancier in the near future</li>
                         <li>update round icon mask</li>
                         <li>Pixel 3, Pixel 3 XL, Pixel 3a, Pixel 3a XL, Pixel 4, Pixel 4 XL, Pixel 4a: always use dark theme for boot chain firmware</li>
                         <li>Pixel 3a, Pixel 3a XL: disable unused dynamic kernel module support to match other devices</li>


### PR DESCRIPTION
Hyphens (-) are different characters than em dashes (—) and using them in this way is incorrect.

https://en.wikipedia.org/wiki/Dash#Em_dash

This replaces hyphens with em dashes where appropriate.