### PR TITLE
Handle USB device reconnection on Android

### DIFF
--- a/static/install/web.html
+++ b/static/install/web.html
@@ -179,7 +179,11 @@
                 Then, proceed to <a href="#locking-the-bootloader">locking the bootloader</a>
                 before using the device as locking wipes the data again.</p>
 
-                <p><strong id="flash-release-status"></strong></p>
+                <p>
+                    <strong id="flash-release-status"></strong>
+                    <!-- This appears as part of the status -->
+                    <button id="flash-reconnect-button" style="display: none;"><strong>Reconnect device</strong></button>
+                </p>
             </section>
 
             <section id="locking-the-bootloader">


### PR DESCRIPTION
On Android, Chromium does not support automatic reconnection. The device needs to be repaired after every reboot in order for fastboot.js to reconnect to it. USB device connction requests are only allowed as the result of explicit user action, so we need to implement a reconnect request callback in the web installer that asks the user to reconnect the device manually.