### PR TITLE
use correct codenames for pixel 4a 5G and pixel 5

### DIFF
--- a/static/build.html
+++ b/static/build.html
@@ -142,8 +142,8 @@
                         <li>aosp_coral (Pixel 4 XL)</li>
                         <li>aosp_flame (Pixel 4)</li>
                         <li>aosp_sunfish (Pixel 4a)</li>
-                        <li>aosp_redfin (Pixel 4a 5G) - experimental</li>
-                        <li>aosp_bramble (Pixel 5) - experimental</li>
+                        <li>aosp_bramble (Pixel 4a 5G) - experimental</li>
+                        <li>aosp_redfin (Pixel 5) - experimental</li>
                     </ul>
 
                     <p>These are all fully supported production-ready targets supporting all the baseline
@@ -389,8 +389,8 @@ cd ../..</pre>
                         <li>
                             Pixel 4a 5G, Pixel 5: redbull
                             <ul>
-                                <li>Pixel 4a 5G: redfin</li>
-                                <li>Pixel 5: bramble</li>
+                                <li>Pixel 4a 5G: bramble</li>
+                                <li>Pixel 5: redfin</li>
                             </ul>
                         </li>
                     </ul>


### PR DESCRIPTION
Use correct codenames for Pixel 4a 5G and Pixel 5. In the current version of the document, both are swapped.
The Pixel 5 should be `redfin`, Pixel 4a 5G should be `bramble`.

References: 
- [Wikipedia Pixel 4a 5G](https://en.wikipedia.org/wiki/Pixel_4a)
- [Wikipedia Pixel 5](https://en.wikipedia.org/wiki/Pixel_5)
- [source.android.com](https://source.android.com/setup/build/building-kernels) *(search for bramble or redfin there)*