### PR TITLE
Pixel 4a 5G & Pixel 5 don't have Pixel Neural Core

### DIFF
--- a/static/usage.html
+++ b/static/usage.html
@@ -313,9 +313,10 @@
                 it's going to be replaced. In the short term, there are other apps available providing
                 more capabilities and better support for taking advantage of the hardware.</p>
 
-                <p>The Pixel 3 (but not the Pixel 3a) and Pixel 4 (but not the Pixel 4a) have a
-                Pixel Visual Core / Pixel Neural Core providing a hardware-based implementation of
-                HDR+. HDR+ captures many images and intelligently merges data across them, taking
+                <p>The Pixel 3 and Pixel 4 have a Pixel Visual Core / Pixel Neural Core providing a hardware-based implementation of
+                HDR+. (Note the Pixel 3a, Pixel 4a, Pixel 4a 5G, and Pixel 5 do not have Pixel Visual Core / Pixel Neural Core) 
+                    
+                HDR+ captures many images and intelligently merges data across them, taking
                 into account motion, etc. It substantially improves the quality of images,
                 especially in low light. This is used transparently for third party apps that are
                 compatible with it, and there isn't an explicit switch to turn it on or off for


### PR DESCRIPTION
A change to indicate that now only Pixel 3 and Pixel 4 have Pixel Visual Core / Pixel Neural Core.