### PR TITLE
Grammarly suggestions

### DIFF
--- a/static/usage.html
+++ b/static/usage.html
@@ -110,7 +110,7 @@
                 first unlock. After installing a TTS service, you need to select it in the OS
                 configuration to accept activating it. The OS will display one of them as already
                 selected but it won't simply work from being installed as that wouldn't be safe.
-                This is the same as the stock OS but it comes with one set up already.</p>
+                This is the same as the stock OS but it comes with one setup already.</p>
 
                 <p>GrapheneOS disables showing the characters as passwords are typed by default.
                 You can enable this in Settings ➔ Privacy.</p>


### PR DESCRIPTION
The word "set up" seems to be miswritten. Consider replacing it.