### PR TITLE
Fix order of table of contents

### DIFF
--- a/static/usage.html
+++ b/static/usage.html
@@ -56,6 +56,7 @@
             <nav id="table-of-contents">
                 <h2><a href="#table-of-contents">Table of contents</a></h2>
                 <ul>
+                    <li><a href="#accessibility">Accessibility</a></li>
                     <li>
                         <a href="#system-navigation">System navigation</a>
                         <ul>
@@ -64,7 +65,6 @@
                             <li><a href="#3-button-navigation">3-button navigation</a></li>
                         </ul>
                     </li>
-                    <li><a href="#accessibility">Accessibility</a></li>
                     <li><a href="#auditor">Auditor</a></li>
                     <li>
                         <a href="#updates">Updates</a>


### PR DESCRIPTION
Accessibility section comes first before System Navigation, but it is the other way around in the Table of Contents