### PR TITLE
Nginx regex: don't capture groups unnecessarily

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -315,7 +315,7 @@ http {
             return 404;
         }
 
-        location ~ "\.(css|js|map|mjs)$" {
+        location ~ "\.(?:css|js|map|mjs)$" {
             include snippets/security-headers.conf;
             add_header Cross-Origin-Resource-Policy "same-origin" always;
             add_header Cache-Control "public, max-age=31536000, immutable";
@@ -336,7 +336,7 @@ http {
             brotli_static off;
         }
 
-        location ~ "\.(atom|pdf)$" {
+        location ~ "\.(?:atom|pdf)$" {
             include snippets/security-headers.conf;
             # Chromium PDF range requests use wrong origin: https://bugs.chromium.org/p/chromium/issues/detail?id=1074261
             # Thunderbird uses wrong origin for feeds: https://bugzilla.mozilla.org/show_bug.cgi?id=1698755
@@ -344,7 +344,7 @@ http {
             add_header Cache-Control "public, max-age=1800";
         }
 
-        location ~ "\.(json|txt|xml)$" {
+        location ~ "\.(?:json|txt|xml)$" {
             include snippets/security-headers.conf;
             add_header Cross-Origin-Resource-Policy "same-origin" always;
             add_header Cache-Control "public, max-age=1800";
@@ -360,7 +360,7 @@ http {
             return 301 /$1;
         }
 
-        location ~ "(/index|\.(br|gz|html))$" {
+        location ~ "/index|\.(?:br|gz|html)$" {
             internal;
         }
 


### PR DESCRIPTION
Good regex form: use "?:" to specify non-capturing groups when sections
don't actually reference matched groups. There's no use saving a capture
in these situations.