### PR TITLE
Add camera app to index.html

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -106,9 +106,10 @@
                     and security. Vanadium is a hardened variant of the Chromium browser and
                     WebView specifically built for GrapheneOS. GrapheneOS also includes our
                     minimal security-focused PDF Viewer, our hardware-based Auditor app /
-                    attestation service providing local and remote verification of devices, and
-                    the externally developed Seedvault encrypted backup which was initially
-                    developed for inclusion in GrapheneOS.</p>
+                    attestation service providing local and remote verification of devices,
+                    our modern privacy / security focused camera app, and the externally developed
+                    Seedvault encrypted backup which was initially developed for inclusion in
+                    GrapheneOS.</p>
                 </section>
 
                 <section id="never-google-services">


### PR DESCRIPTION
Adds camera app to frontpage list of GrapheneOS developed apps and services.