### PR TITLE
Erase FIPS partition during installation

### DIFF
--- a/static/releases.html
+++ b/static/releases.html
@@ -513,6 +513,7 @@
                         <li>Pixel 3, Pixel 3 XL, Pixel 3a, Pixel 3a XL, Pixel 4, Pixel 4 XL, Pixel 4a, Pixel 4a (5G), Pixel 5, Pixel 5a: include empty apdp image in updates to wipe persistent debugging policy</li>
                         <li>Pixel 3, Pixel 3 XL, Pixel 3a, Pixel 3a XL, Pixel 4, Pixel 4 XL, Pixel 4a: erase both msadp partition slots as part of flashing factory images to wipe persistent debugging policy</li>
                         <li>Pixel 3, Pixel 3 XL, Pixel 3a, Pixel 3a XL, Pixel 4, Pixel 4 XL, Pixel 4a: include empty msapd image in updates to wipe persistent debugging policy</li>
+                        <li>Pixel 6, Pixel 6 Pro: erase fips partition as part of flashing factory images to wipe persistent FIPS policy</li>
                         <li>kernel (Pixel 3, Pixel 3 XL, Pixel 3a, Pixel 3a XL): enable BUG_ON_DATA_CORRUPTION since it was backported upstream</li>
                         <li>kernel (Pixel 3, Pixel 3 XL, Pixel 3a, Pixel 3a XL, Pixel 4, Pixel 4 XL, Pixel 4a): enable legacy Qualcomm PANIC_ON_DATA_CORRUPTION since it hasn't been fully phased out yet</li>
                         <li>Seedvault: temporarily revert change to restore requiring that the profile is unlocked for the hardware keystore key (uncovers an upstream bug)</li>


### PR DESCRIPTION
was accidentally removed from release notes