### PR TITLE
Add bootflow details to install pages

### DIFF
--- a/static/install/cli.html
+++ b/static/install/cli.html
@@ -498,7 +498,12 @@ curl -O https://releases.grapheneos.org/DEVICE_NAME-factory-2021110122.zip.sig</
 
                     <p>You've now successfully installed GrapheneOS and can boot it. Pressing the
                     power button with the default Start option selected in the bootloader
-                    interface will boot the OS.</p>
+                    interface will boot the OS. On every boot the device will show a text 
+                    "Your device is loading a different operating system." and a yellow screen. 
+                    This is because a custom root of trust has been set, and the images were 
+                    signed with this custom root of trust. The yellow screen is dismissed after 
+                    ten seconds and the device continues booting. After that the device will 
+                    show Google logo on Pixel devices and after that GrapheneOS logo.</p>
                 </section>
 
                 <section id="disabling-oem-unlocking">

--- a/static/install/web.html
+++ b/static/install/web.html
@@ -307,7 +307,12 @@
 
                     <p>You've now successfully installed GrapheneOS and can boot it. Pressing the
                     power button with the default Start option selected in the bootloader
-                    interface will boot the OS.</p>
+                    interface will boot the OS. On every boot the device will show a text 
+                    "Your device is loading a different operating system." and a yellow screen. 
+                    This is because a custom root of trust has been set, and the images were 
+                    signed with this custom root of trust. The yellow screen is dismissed after 
+                    ten seconds and the device continues booting. After that the device will 
+                    show Google logo on Pixel devices and after that GrapheneOS logo.</p>
                 </section>
 
                 <section id="disabling-oem-unlocking">


### PR DESCRIPTION
Many people in the Matrix rooms seems to be confused about the "Your device is loading a different OS" message and the Google logo so thats why I think this would be a good idea.