### PR TITLE
install/cli: remove signify silent option, since an verified output is expected

### DIFF
--- a/static/install/cli.html
+++ b/static/install/cli.html
@@ -410,8 +410,9 @@ curl -O https://releases.grapheneos.org/DEVICE_NAME-factory-2021110122.zip.sig</
 
                 <pre>signify -Cqp factory.pub -x DEVICE_NAME-factory-2021110122.zip.sig &amp;&amp; echo verified</pre>
 
-                <p>This will output <code>verified</code> if verification is successful. If something
-                goes wrong, it will output an error message rather than <code>verified</code>.</p>
+                <p>Depending on your signify version, this will output <code>verified</code> or
+                nothing if verification is successful. If something goes wrong, it will output an
+                error message.</p>
             </section>
 
             <section id="flashing-factory-images">


### PR DESCRIPTION
On ArchLinux there is no output at all, which is very confusing. Removing the -q option gives an output:
```
Signature Verified
oriole-factory-2022011423.zip: OK
```