### PR TITLE
Remove note about Play Store uninstallation stalling

### DIFF
--- a/static/usage.html
+++ b/static/usage.html
@@ -969,10 +969,6 @@
                     for OS services. In cases such as text-to-speech (TTS) where the OS allows the
                     user to choose the provider, Play services can often be used. It's on a level
                     playing field with other apps on GrapheneOS.</p>
-
-                    <p>Play Store assumes that uninstallation always succeeds so it will stall if
-                    it tries to uninstall an app and you reject it. You can work around this by
-                    force stopping and then reopening it.</p>
                 </section>
 
                 <section id="sandboxed-google-play-esim">


### PR DESCRIPTION
The Play Store no longer stalls when uninstalling an app if the user rejects the request as of 2022041900, so we can remove this section.