### PR TITLE
This is now handled by backporting upstream patch

### DIFF
--- a/static/build.html
+++ b/static/build.html
@@ -834,8 +834,7 @@ git checkout $CORRECT_BRANCH_OR_TAG</pre>
                     <pre>cd src
 git fetch --tags
 git checkout $VERSION
-gclient sync -D --with_branch_heads --with_tags --jobs 32
-third_party/android_deps/fetch_all.py --ignore-vulnerabilities</pre>
+gclient sync -D --with_branch_heads --with_tags --jobs 32</pre>
 
                     <p>Apply the GrapheneOS patches on top of the tagged release:</p>
 


### PR DESCRIPTION
Recently, Chromium dev team has updated public gms library here, https://source.chromium.org/chromium/chromium/src/+/b45469c1f4f4cdaa14813db8d9fbe455fabd8459

It can be backported and cherry-picked in the future versions until it lands on a major version tag of Chromium