### PR TITLE
Add "Origin-Agent-Cluster" header

### DIFF
--- a/nginx/snippets/security-headers-base.conf
+++ b/nginx/snippets/security-headers-base.conf
@@ -3,6 +3,7 @@ add_header X-Content-Type-Options "nosniff" always;
 add_header Referrer-Policy "no-referrer" always;
 add_header Cross-Origin-Opener-Policy "same-origin" always;
 add_header Cross-Origin-Embedder-Policy "require-corp" always;
+add_header Origin-Agent-Cluster "?1" always;
 
 # obsolete when client system time is correct
 add_header Expect-CT "enforce, max-age=63072000" always;


### PR DESCRIPTION
Hint to browsers that we prefer per-origin process isolation. This
disables certain unsafe features regarding cross-origin same-site
resource sharing.

https://web.dev/origin-agent-cluster/#limitations

Specification link:
https://html.spec.whatwg.org/multipage/origin.html#origin-keyed-agent-clusters

This is just a hint to browsers. Depending on resource availability,
they may or may not actually allocate a process. For this reason, it's
not a robust security feature although it is preferable.

This header needs to be active on all pages from an origin for it to
work.