### PR TITLE
Add Document-Policy header

### DIFF
--- a/nginx/snippets/security-headers.conf
+++ b/nginx/snippets/security-headers.conf
@@ -3,3 +3,5 @@ include snippets/security-headers-base.conf;
 add_header Content-Security-Policy "default-src 'none'; connect-src 'self' https://releases.grapheneos.org/; font-src 'self'; img-src 'self'; manifest-src 'self'; script-src 'self'; style-src 'self'; form-action 'none'; frame-ancestors 'none'; block-all-mixed-content; base-uri 'none'; require-trusted-types-for 'script'; trusted-types 'none'" always;
 
 add_header Permissions-Policy "accelerometer=(), ambient-light-sensor=(), autoplay=(), battery=(), camera=(), clipboard-read=(), clipboard-write=(), display-capture=(), document-domain=(), encrypted-media=(), fullscreen=(), gamepad=(), geolocation=(), gyroscope=(), hid=(), idle-detection=(), interest-cohort=(), magnetometer=(), microphone=(), midi=(), payment=(), picture-in-picture=(), publickey-credentials-get=(), screen-wake-lock=(), serial=(), speaker-selection=(), sync-xhr=(), usb=(), xr-spatial-tracking=()" always;
+
+add_header Document-Policy "document-domain=?0, document-write=?0, popups=?0, js-profiling=?0" always;


### PR DESCRIPTION
This header accomplishes the following:

- Forbids document.write
- Forbids document.domain
- Forbids use of profiling APIs
- Forbids popups (similar to the overly-agressive "sandbox" CSP
  directive; uplifed from the deprecated Feature-Policy header)

These are preffed off in Chromium as "experimental"; the only DP
directive currently enabled in Chromium is "force-load-at-top".

More information:

- Document-Policy explainer:
  https://github.com/wicg/document-policy/blob/main/document-policy-explainer.md

- Document-Policy specification:
  https://wicg.github.io/document-policy/

- Current directives supported in Chromium:
  https://chromium.googlesource.com/chromium/src/+/refs/heads/main/third_party/blink/renderer/core/permissions_policy/document_policy_features.json5

To try this out, go to "chrome://flags" and enable experimental web
platform features. See implementation status at
https://bugs.chromium.org/p/chromium/issues/detail?id=993790.