### PR TITLE
Feat: use TLS record padding

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -45,6 +45,7 @@ http {
     ssl_ciphers ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256;
     ssl_prefer_server_ciphers on;
     ssl_conf_command Options PrioritizeChaCha;
+    ssl_conf_command RecordPadding 1024;
 
     ssl_certificate /etc/letsencrypt/live/grapheneos.org/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/grapheneos.org/privkey.pem;


### PR DESCRIPTION
Use TLS record padding to make records a multiple of 1024 bytes,
impeding traffic analysis.