### PR TITLE
Update certbot-ocsp-fetcher

### DIFF
--- a/certbot-replicate
+++ b/certbot-replicate
@@ -10,6 +10,6 @@ for replica in ${replicas[@]}; do
     echo
 
     rsync -rptvl --fsync --delete /etc/letsencrypt/ $replica:/etc/letsencrypt
-    rsync -rptvl --fsync --delete /etc/nginx/ocsp-cache/ $replica:/etc/nginx/ocsp-cache
+    rsync -rptvl --fsync --delete /var/certbot-ocsp-fetcher/ $replica:/var/certbot-ocsp-fetcher/
     ssh root@$replica nginx -s reload
 done

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -61,7 +61,7 @@ http {
     ssl_stapling on;
     ssl_stapling_verify on;
     # maintained by certbot-ocsp-fetcher
-    ssl_stapling_file ocsp-cache/grapheneos.org.der;
+    ssl_stapling_file /var/certbot-ocsp-fetcher/grapheneos.org.der;
 
     log_format main '$remote_addr - $remote_user [$time_local] '
                     '"$request_method $scheme://$host$request_uri $server_protocol" $status $body_bytes_sent '


### PR DESCRIPTION
certbot-ocsp-fetcher now can use a Systemd cache dir and service sandboxing. See tomwassenberg/certbot-ocsp-fetcher#19

Depends on https://github.com/GrapheneOS/infrastructure/pull/10