### PR TITLE
Add kernel folder info for redbull

### DIFF
--- a/static/build.html
+++ b/static/build.html
@@ -436,7 +436,8 @@ repo sync -j16</pre>
                         <pre>BUILD_CONFIG=private/msm-google/build.config.redbull.vintf build/build.sh</pre>
 
                         <p>Replace the files in the OS source tree at
-                        <code>device/google/redbull-kernel/</code> with your build in
+                        <code>device/google/redbull-kernel/</code> (development build) or 
+                        <code>device/google/redbull-kernel/vintf/</code> (production build) with your build in
                         <code>out/android-msm-pixel-4.19/dist/</code>.</p>
                     </section>
 


### PR DESCRIPTION
The target folder for the redbull kernel depends on the build type (development or production). 