### PR TITLE
Add warning for Flatpak and Snap browsers in the Web Install Page

### DIFF
--- a/static/install/web.html
+++ b/static/install/web.html
@@ -145,6 +145,8 @@
                     <li>Microsoft Edge</li>
                     <li>Brave</li>
                 </ul>
+                
+                <p>You should avoid Flatpak and Snap versions of browsers, as they're known to cause issues during the installation process.</p>
 
                 <p>Make sure your browser is up-to-date before proceeding.</p>
 


### PR DESCRIPTION
This adds a general warning against sourcing Snap and Flatpak versions of browsers for the purposes of the web install, as they've both proven to be problematic with the flashing process.