### PR TITLE
Use a variable for the certificate Common Name instead

### DIFF
--- a/static/build.html
+++ b/static/build.html
@@ -654,13 +654,14 @@ vendor/adevtool/bin/run ota-firmware vendor/adevtool/config/<var>DEVICE</var>.ym
 
                     <pre>mkdir -p keys/raven
 cd keys/raven
-../../development/tools/make_key releasekey '/CN=GrapheneOS/'
-../../development/tools/make_key platform '/CN=GrapheneOS/'
-../../development/tools/make_key shared '/CN=GrapheneOS/'
-../../development/tools/make_key media '/CN=GrapheneOS/'
-../../development/tools/make_key networkstack '/CN=GrapheneOS/'
-../../development/tools/make_key sdk_sandbox '/CN=GrapheneOS/'
-../../development/tools/make_key bluetooth '/CN=GrapheneOS/'
+CN=GrapheneOS
+../../development/tools/make_key releasekey "/CN=$CN/"
+../../development/tools/make_key platform "/CN=$CN/"
+../../development/tools/make_key shared "/CN=$CN/"
+../../development/tools/make_key media "/CN=$CN/"
+../../development/tools/make_key networkstack "/CN=$CN/"
+../../development/tools/make_key sdk_sandbox "/CN=$CN/"
+../../development/tools/make_key bluetooth "/CN=$CN/"
 openssl genrsa 4096 | openssl pkcs8 -topk8 -scrypt -out avb.pem
 ../../external/avb/avbtool extract_public_key --key avb.pem --output avb_pkmd.bin
 cd ../..</pre>


### PR DESCRIPTION
Lot easier to change the CN like this and produces the exact same output according to OpenSSL (`openssl x509 -noout -subject -in releasekey.x509.pem`)

Signed-off-by: r3g_5z <june@girlboss.ceo>