### PR TITLE
Removed extra space in ` / ` string.

### DIFF
--- a/static/articles/index.html
+++ b/static/articles/index.html
@@ -73,7 +73,7 @@
                 <li><a href="/articles/attestation-compatibility-guide">Attestation compatibility guide</a> — Guide on using remote attestation in a way that's compatible with GrapheneOS</li>
                 <li><a href="/articles/grapheneos-servers">GrapheneOS servers</a> — Documentation on GrapheneOS servers.</li>
                 <li><a href="/articles/server-traffic-shaping">Server traffic shaping</a> — Implementing server traffic shaping on Linux with CAKE.</li>
-                <li><a href="/articles/sitewide-advertising-industry-opt-out">Sitewide advertising industry opt-out</a> — Using ads.txt / app-ads.txt to disallow buying or selling ads for a domain.</li>
+                <li><a href="/articles/sitewide-advertising-industry-opt-out">Sitewide advertising industry opt-out</a> — Using ads.txt/app-ads.txt to disallow buying or selling ads for a domain.</li>
             </ul>
         </main>
         <footer>

--- a/static/articles/server-traffic-shaping.html
+++ b/static/articles/server-traffic-shaping.html
@@ -240,7 +240,7 @@ PriorityQueueingPreset=besteffort</pre>
 
                 <p>If you decide to use <code>tcp_notsent_lowat</code>, be aware that newer Linux
                 kernels (Linux 5.0+ with a further improvement for Linux 5.10+) are recommended to
-                substantially reduce system calls/context switches by not triggering the
+                substantially reduce system calls / context switches by not triggering the
                 application to provide more data until over half the unsent byte buffer is
                 empty.</p>
             </section>

--- a/static/articles/server-traffic-shaping.html
+++ b/static/articles/server-traffic-shaping.html
@@ -240,7 +240,7 @@ PriorityQueueingPreset=besteffort</pre>
 
                 <p>If you decide to use <code>tcp_notsent_lowat</code>, be aware that newer Linux
                 kernels (Linux 5.0+ with a further improvement for Linux 5.10+) are recommended to
-                substantially reduce system calls / context switches by not triggering the
+                substantially reduce system calls/context switches by not triggering the
                 application to provide more data until over half the unsent byte buffer is
                 empty.</p>
             </section>

--- a/static/articles/sitewide-advertising-industry-opt-out.html
+++ b/static/articles/sitewide-advertising-industry-opt-out.html
@@ -64,8 +64,8 @@
             <pre>placeholder.example.com, placeholder, DIRECT, placeholder</pre>
 
             <p>The placeholder record formally disallows buying and selling ads on behalf of the
-            domain including for any subdomains. This prevents fradulently buying / selling ads
-            for your domain anywhere that ads.txt / app-ads.txt are enforced.</p>
+            domain including for any subdomains. This prevents fradulently buying/selling ads
+            for your domain anywhere that ads.txt/app-ads.txt are enforced.</p>
 
             <p>It's in the interest of most ad tech companies to enforce these standards due to
             losses from ad fraud so adoption is increasingly widespread.</p>

--- a/static/build.html
+++ b/static/build.html
@@ -162,9 +162,9 @@
 
                     <p>These are all fully supported production-ready targets supporting all the
                     baseline security features and receiving full monthly security updates
-                    covering all firmware, kernel drivers, driver libraries / services and other
+                    covering all firmware, kernel drivers, driver libraries/services and other
                     device-specific code. A fully signed user build for these devices is a proper
-                    GrapheneOS release. Newer generation devices have stronger hardware / firmware
+                    GrapheneOS release. Newer generation devices have stronger hardware/firmware
                     security and hardware-based OS security features and are better development
                     devices for that reason. It's not possible to work on everything via past
                     generation devices. The best development devices are the Pixel 6 and 7 series.
@@ -204,8 +204,8 @@
                     an up-to-date kernel and device support code including driver libraries, firmware and
                     device SELinux policy extensions. Other than some special cases like the emulator, the
                     generic targets rely on the device support code present on the device. Shipping all of
-                    this is necessary for full security updates and is tied to enabling verified boot /
-                    attestation. Pixel targets have a lot of device-specific hardening in the AOSP base
+                    this is necessary for full security updates and is tied to enabling verified boot/attestation.
+                    Pixel targets have a lot of device-specific hardening in the AOSP base
                     along with some in GrapheneOS which needs to be ported over too. For example, various
                     security features in the kernel including type-based Control Flow Integrity (CFI) and
                     the shadow call stack are currently specific to the kernels for these devices.</p>
@@ -326,7 +326,7 @@
                         officially supported devices.</p>
 
                         <p>The <code>13</code> branch is used for 4th, 5th, 6th and 7th generation
-                        Pixels, generic / emulator targets and non-Pixel devices:</p>
+                        Pixels, generic/emulator targets and non-Pixel devices:</p>
 
                         <pre>mkdir grapheneos-13
 cd grapheneos-13
@@ -345,7 +345,7 @@ repo sync -j16</pre>
                         and download the source tree. Note that some devices use different Android Open Source
                         Project branches so they can end up with different tags. Make sure to use the correct
                         tag for a device. For devices without official support, use the latest tag marked as
-                        being appropriate for generic / other devices in the release notes.</p>
+                        being appropriate for generic/other devices in the release notes.</p>
 
                         <pre>mkdir grapheneos-<var>TAG_NAME</var>
 cd grapheneos-<var>TAG_NAME</var>
@@ -1140,7 +1140,7 @@ rm android-cts-media-1.5.zip</pre>
                             <li>Disable SIM lock</li>
                             <li>Enable Bluetooth</li>
                             <li>Enable NFC</li>
-                            <li>Open / close Chromium to deal with initial setup</li>
+                            <li>Open/close Chromium to deal with initial setup</li>
                             <li>Prop up with a good object to focus on and good lighting for Camera tests.
                             Both the front and rear cameras will be used, so ensure this is true for both the
                             front and the rear cameras.</li>
@@ -1181,7 +1181,7 @@ rm android-cts-media-1.5.zip</pre>
                 different components. There are tags and/or branches for the OS, device kernels,
                 mainline components (APEX), the NDK, Android Studio, the platform-tools distribution
                 packages, the CTS, androidx components, etc. You should obtain the sources via
-                manifests using the repo tool, either using the manifest for a tag / branch in
+                manifests using the repo tool, either using the manifest for a tag/branch in
                 platform/manifest.git or a manifest provided elsewhere. Different projects use
                 different subsets of the repositories. Many of the repositories only exist as an
                 archive for older releases and aren't referenced in current manifests.</p>
@@ -1271,8 +1271,8 @@ rm android-cts-media-1.5.zip</pre>
                     <code>variable_name</code>, <code>TypeName</code> and <code>CONSTANT_NAME</code>.
                     Prefer single-line comment syntax other than rare cases where it makes sense to add a
                     tiny comment within a line of code. In languages with the optional braces misfeature
-                    (C, C++, Java), always use them. Open braces on the same line as function definitions
-                    / statements. Wrap lines at 100 columns except in rare cases where it would be far
+                    (C, C++, Java), always use them. Open braces on the same line as function definitions/statements. 
+                    Wrap lines at 100 columns except in rare cases where it would be far
                     uglier to wrap the line.</p>
 
                     <p>For JavaScript, all code should be contained within ES6 modules. This means every

--- a/static/contact.html
+++ b/static/contact.html
@@ -136,8 +136,8 @@
 
                 <p>Do not contact us with offers to sell us products or services.</p>
 
-                <p>Please don't contact the GrapheneOS project or developers to request support /
-                device support / features or to report bugs. Use the <a href="#community">community
+                <p>Please don't contact the GrapheneOS project or developers to request support/device support/features 
+                or to report bugs. Use the <a href="#community">community
                 platforms</a> and <a href="#reporting-issues">issue trackers</a> listed below. The
                 developers are active on the Matrix room but the broader community can usually
                 answer most questions, and this allows the developers to focus their time and
@@ -149,7 +149,7 @@
                 a message to be read, only as a regular notification that is likely to be missed or
                 forgotten.</p>
 
-                <p>Please do not send multiple copies / versions of the same email to different
+                <p>Please do not send multiple copies/versions of the same email to different
                 addresses. Either send it to a single address or CC the other addresses. In general,
                 it's the same person handling every email address, and they don't need to see multiple
                 copies of the same email in their inbox.</p>

--- a/static/faq.html
+++ b/static/faq.html
@@ -264,8 +264,8 @@
                     standard hardware-based security features like the hardware-backed keystores, verified
                     boot, attestation and various hardware-based exploit mitigations need to be available.
                     Devices also need to have decent integration of IOMMUs for isolating components such
-                    as the GPU, radios (NFC, Wi-Fi, Bluetooth, Cellular), media decode / encode, image
-                    processor, etc., because if the hardware / firmware support is missing or broken,
+                    as the GPU, radios (NFC, Wi-Fi, Bluetooth, Cellular), media decode/encode, image
+                    processor, etc., because if the hardware/firmware support is missing or broken,
                     there's not much that the OS can do to provide an alternative. Devices with support for
                     alternative operating systems as an afterthought will not be considered. Devices need
                     to have proper ongoing support for their firmware and software specific to the hardware
@@ -477,7 +477,7 @@
                     with metadata encryption. All data, file names and other metadata is always
                     stored encrypted. This is often referred to as file-based encryption but it
                     makes more sense to call it filesystem-based encryption. It's implemented by
-                    the Linux kernel as part of the ext4 / f2fs implementation rather than running
+                    the Linux kernel as part of the ext4/f2fs implementation rather than running
                     a block-based encryption layer. The advantage of filesystem-based encryption
                     is the ability to use fine-grained keys rather than a single global key that's
                     always in memory once the device is booted.</p>
@@ -702,7 +702,7 @@
                     GrapheneOS also avoids trust in the cellular network in other ways including providing
                     a secure network time update implementation rather than trusting the cellular network
                     for this. Time is sensitive and can be used to bypass security checks depending on
-                    certificate / key expiry.</p>
+                    certificate/key expiry.</p>
 
                     <p>Cellular networks use inherently insecure protocols and have many trusted parties.
                     Even if interception of the connection or some other man-in-the-middle attack along
@@ -716,9 +716,9 @@
                     recommend apps taking a decent approach in this area.</p>
 
                     <p>Legacy calls and texts should be avoided as they're not secure and trust the
-                    carrier / network along with having weak security against other parties. Trying to
+                    carrier/network along with having weak security against other parties. Trying to
                     detect some forms of interception rather than dealing with the root of the problem
-                    (unencrypted communications / data transfer) would be foolish and doomed to
+                    (unencrypted communications/data transfer) would be foolish and doomed to
                     failure.</p>
 
                     <p>GrapheneOS does not add gimmicks without a proper threat model and
@@ -768,8 +768,8 @@
                     <h3><a href="#default-connections">What kind of connections do the OS and bundled apps make by default?</a></h3>
 
                     <p>GrapheneOS makes connections to the outside world to test connectivity, detect
-                    captive portals and download updates. No data varying per user / installation / device
-                    is sent in these connections. There aren't analytics / telemetry in GrapheneOS.</p>
+                    captive portals and download updates. No data varying per user/installation/device
+                    is sent in these connections. There aren't analytics/telemetry in GrapheneOS.</p>
 
                     <p>The expected default connections by GrapheneOS (including all base system apps) are
                     the following:</p>
@@ -783,7 +783,7 @@
                             https://releases.grapheneos.org/DEVICE-incremental-OLD_VERSION-NEW_VERSION.zip
                             for a delta update, and then falls back to
                             https://releases.grapheneos.org/DEVICE-ota_update-NEW_VERSION.zip.</p>
-                            <p>No query / data is sent to the server, so the only information leaked to it
+                            <p>No query/data is sent to the server, so the only information leaked to it
                             are the variables in these 3 URLs (device, channel, current version) which is
                             necessary to obtain the update.</p>
                             <p>Users are in control of which types of networks the Updater app will use
@@ -811,7 +811,7 @@
                             standard network time update implementation, which uses the cellular network
                             when available with a fallback to SNTP when it's not available. Network time
                             updates are security sensitive since certificate validation depends on having
-                            an accurate time, but the standard NTP / SNTP protocols used across most OSes
+                            an accurate time, but the standard NTP/SNTP protocols used across most OSes
                             have no authentication.</p>
 
                             <p>We plan to offer a toggle to use the standard functionality instead of
@@ -885,7 +885,7 @@
 
                             <pre>Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.32 Safari/537.36</pre>
 
-                            <p>No query / data is sent to the servers and the response is unused beyond
+                            <p>No query/data is sent to the servers and the response is unused beyond
                             checking the response code.</p>
 
                             <p>Connectivity checks are performed for each network connection and
@@ -991,7 +991,7 @@
                         </li>
                         <li>
                             <p>DNS resolution for other connections involving connections to the
-                            network / user provided DNS resolvers</p>
+                            network/user provided DNS resolvers</p>
                         </li>
                     </ul>
 
@@ -1265,7 +1265,7 @@
                     <p>Apps and web sites can detect that ad-blocking is being used and can
                     determine what's being blocked. This can be used as part of fingerprinting
                     users. Using a widely used service like AdGuard with a standard block list is
-                    much less of an issue than a custom set of subscriptions / rules, but it still
+                    much less of an issue than a custom set of subscriptions/rules, but it still
                     stands out compared to the default of not doing it.</p>
                 </article>
 
@@ -1414,7 +1414,7 @@
                     <h3><a href="#file-transfer">How do I transfer files to another device?</a></h3>
 
                     <p>Files can be transferred to another device using an external drive, USB
-                    file transfer via MTP / PTP or an app-based mechanism.</p>
+                    file transfer via MTP/PTP or an app-based mechanism.</p>
 
                     <p>To use an external drive, plug it into the phone and use the system file
                     manager to copy files to and from it. The only difference on GrapheneOS is USB
@@ -1422,7 +1422,7 @@
                     at boot or when the device is unlocked. You can configure this in Settings ➔
                     Security.</p>
 
-                    <p>Transferring files to an attached computer is done with MTP / PTP. Users on
+                    <p>Transferring files to an attached computer is done with MTP/PTP. Users on
                     a Mac computer will need to install
                     <a href="https://www.android.com/filetransfer/">Android File Transfer</a> to be
                     able to transfer files between macOS and Android. After plugging in the phone
@@ -1746,7 +1746,7 @@
             <article id="company">
                 <h2><a href="#company">Will GrapheneOS create a company?</a></h2>
 
-                <p>No, GrapheneOS will remain a non-profit open source project / organization. It
+                <p>No, GrapheneOS will remain a non-profit open source project/organization. It
                 will remain an independent organization not strongly associated with any specific
                 company. We partner with a variety of companies and other organizations, and we're
                 interested in more partnerships in the future. Keeping it as an non-profit avoids

--- a/static/features.html
+++ b/static/features.html
@@ -338,7 +338,7 @@
                                     including many which we played a part in developing and
                                     landing upstream as part of our linux-hardened project (which
                                     we intend to revive as a more active project again).</li>
-                                    <li>Forced kernel module signing with per-build RSA 4096/SHA256
+                                    <li>Forced kernel module signing with per-build RSA 4096 / SHA256
                                     keys and lockdown mode set to forced confidentiality
                                     mode help to enforce a low-level boundary between the kernel
                                     and userspace even if mistakes are made in SELinux policy or
@@ -895,7 +895,7 @@
                         features being enabled.</li>
                         <li>Authenticated encryption for network time updates via a first party server to
                         prevent attackers from changing the time and enabling attacks based on bypassing
-                        certificate/key expiry, etc.</li>
+                        certificate / key expiry, etc.</li>
                         <li>Proper support for disabling network time updates rather than just not using
                         the results</li>
                         <li>Hardened local build/signing infrastructure</li>

--- a/static/features.html
+++ b/static/features.html
@@ -99,8 +99,7 @@
                                     mitigations</a></li>
                                     <li><a href="#improved-sandboxing">Improved
                                     sandboxing</a></li>
-                                    <li><a href="#anti-persistence">Anti-persistence /
-                                    detection</a></li>
+                                    <li><a href="#anti-persistence">Anti-persistence/detection</a></li>
                                 </ul>
                             </li>
                             <li><a href="#more-complete-patching">More complete patching</a></li>
@@ -210,26 +209,26 @@
                     weaker less complete exploit mitigations can still provide meaningful barriers
                     against attacks as long as they're developed with a clear threat model.
                     GrapheneOS is heavily invested in many areas of developing these protections:
-                    developing/deploying memory safe languages / libraries, static/dynamic
+                    developing/deploying memory safe languages/libraries, static/dynamic
                     analysis tooling and many kinds of mitigations.</p>
 
                     <p>The final line of defense is containment through sandboxing at various
                     levels: fine-grained sandboxes around a specific context like per site browser
                     renderers, sandboxes around a specific component like Android's media codec
-                    sandbox and app / workspace sandboxes like the Android app sandbox used to
+                    sandbox and app/workspace sandboxes like the Android app sandbox used to
                     sandbox each app which is also the basis for user/work profiles. GrapheneOS
                     improves all of these sandboxes through fortifying the kernel and other base
                     OS components along with improving the sandboxing policies.</p>
 
                     <p>Preventing an attacker from persisting their control of a component or the
-                    OS / firmware through verified boot and avoiding trust in persistent state
+                    OS/firmware through verified boot and avoiding trust in persistent state
                     also helps to mitigate the damage after a compromise has occurred.</p>
 
                     <p>Remote code execution vulnerabilities are the most serious and allow an
                     attacker to gain a foothold on device or even substantial control over it
                     remotely. Local code execution vulnerabilities allow breaking out of a sandbox
                     including the app sandbox or browser renderer sandbox after either
-                    compromising an app / browser renderer remotely, compromising an app's supply
+                    compromising an app/browser renderer remotely, compromising an app's supply
                     chain or getting the user to install a malicious app. Many other kinds of
                     vulnerabilities exist but most of what we're protecting against falls into
                     these 2 broad categories.</p>
@@ -339,12 +338,12 @@
                                     including many which we played a part in developing and
                                     landing upstream as part of our linux-hardened project (which
                                     we intend to revive as a more active project again).</li>
-                                    <li>Forced kernel module signing with per-build RSA 4096 /
-                                    SHA256 keys and lockdown mode set to forced confidentiality
+                                    <li>Forced kernel module signing with per-build RSA 4096/SHA256
+                                    keys and lockdown mode set to forced confidentiality
                                     mode help to enforce a low-level boundary between the kernel
                                     and userspace even if mistakes are made in SELinux policy or
                                     there's a deep userspace compromise.</li>
-                                    <li>Additional consistency / integrity checks are enabled for
+                                    <li>Additional consistency/integrity checks are enabled for
                                     frequently targeted kernel data structures.</li>
                                 </ul>
                             </li>
@@ -379,7 +378,7 @@
                     </section>
 
                     <section id="anti-persistence">
-                        <h4><a href="#anti-persistence">Anti-persistence / detection</a></h4>
+                        <h4><a href="#anti-persistence">Anti-persistence/detection</a></h4>
 
                         <ul>
                             <li>Enhanced <a href="https://source.android.com/docs/security/features/verifiedboot">verified boot</a>
@@ -455,7 +454,7 @@
                     compatibility layer.</p>
 
                     <p>The vast majority of Play services functionality works perfectly including
-                    dynamically downloaded / updated modules (dynamite modules) and functionality
+                    dynamically downloaded/updated modules (dynamite modules) and functionality
                     provided by modular app components such as Google Play Games. By default,
                     location requests are rerouted to a reimplementation of the Play geolocation
                     service provided by GrapheneOS. You can disable rerouting and use the standard
@@ -464,7 +463,7 @@
 
                     <p>Our compatibility layer includes full support for the Play Store. Play
                     Store services are fully available including in-app purchases, Play Asset
-                    Delivery, Play Feature Delivery and app / content license checks. It can
+                    Delivery, Play Feature Delivery and app/content license checks. It can
                     install, update and uninstall apps with the standard approach requiring that
                     the user authorizes it as an app source and consents to each action. It will
                     use the standard Android 12+ unattended update feature to do automatic updates
@@ -862,7 +861,7 @@
                     all location data accesses through any APIs. Normally, the stock OS only shows
                     it for GNSS location requests, also known as high power location requests, and
                     doesn't normally show it for network location and other APIs gated by the
-                    Location permission / global block toggle.</p>
+                    Location permission/global block toggle.</p>
 
                     <p>The indicator works the same way as the Camera and Microphone ones, showing
                     a bright green icon when location access occurs which then gets minimized to a
@@ -896,10 +895,10 @@
                         features being enabled.</li>
                         <li>Authenticated encryption for network time updates via a first party server to
                         prevent attackers from changing the time and enabling attacks based on bypassing
-                        certificate / key expiry, etc.</li>
+                        certificate/key expiry, etc.</li>
                         <li>Proper support for disabling network time updates rather than just not using
                         the results</li>
-                        <li>Hardened local build / signing infrastructure</li>
+                        <li>Hardened local build/signing infrastructure</li>
                         <li><a href="/usage#updates">Seamless automatic OS update system</a> that just
                         works and stays out of the way in the background without disrupting device
                         usage, with full support for the standard automatic rollback if the first boot
@@ -919,11 +918,11 @@
                         <li>Secure-by-default Android 12 PendingIntent security check (FLAG_IMMUTABLE)
                         instead of crash-by-default improving older app compatibility and security.</li>
                         <li>Fixed UART debugging enabled warning on offical release builds.</li>
-                        <li>Engineering / Prototype ("EVT", "PVT" or "DVT") device warning as these
+                        <li>Engineering/Prototype ("EVT", "PVT" or "DVT") device warning as these
                         devices typically have relaxed security controls for development, mainly
                         the secure boot state property <code>ro.boot.secure_boot</code> not set
                         to <code>PRODUCTION</code>.</li>
-                        <li>Enable bootloader, radio, and boot partition version / fingerprint
+                        <li>Enable bootloader, radio, and boot partition version/fingerprint
                         checks.</li>
                         <li>Remove code automatically granting the location permission to system
                         browsers.</li>

--- a/static/releases.html
+++ b/static/releases.html
@@ -694,7 +694,7 @@
                     <p>Changes since the 2023011000 release:</p>
 
                     <ul>
-                        <li>don't send IMSI / Phone number to SUPL server when SUPL is enabled (note: using SUPL is always an optional choice in APN configuration on GrapheneOS, unlike AOSP and the stock OS)</li>
+                        <li>don't send IMSI/Phone number to SUPL server when SUPL is enabled (note: using SUPL is always an optional choice in APN configuration on GrapheneOS, unlike AOSP and the stock OS)</li>
                         <li>SELinux policy: drop auditing for apk_data_file execute/execute_no_trans (research is done)</li>
                         <li>SELinux policy: add back apk_data_file execute/execute_no_trans for adb shell for debugging use cases (removing it isn't really useful for hardening and we plan on hardening ADB for the verified boot model another way)</li>
                         <li>Settings: revert to standard Android 13 minimum threshold of 10% for automatic battery saver since lowering it below 10% doesn't work as intended without more invasive changes outside the scope of GrapheneOS</li>
@@ -835,7 +835,7 @@
                         <li>kernel (Pixel 6, Pixel 6 Pro, Pixel 6a, Pixel 7, Pixel 7 Pro, Generic 5.10): revert 5.10.157 IRQ changes breaking boot on Pixel 7 and Pixel 7 Pro</li>
                         <li>adevtool: stop including unused install constraint configuration</li>
                         <li>adevtool: stop including stock OS root CA database</li>
-                        <li>include Apps (app repository client) in managed profiles by default in order to support installing / updating sandboxed Google Play</li>
+                        <li>include Apps (app repository client) in managed profiles by default in order to support installing/updating sandboxed Google Play</li>
                         <li>change DNS-over-TLS connectivity check to querying for <code><var>randomstring</var>-dnsotls-ds.dnscheck.grapheneos.org</code> rather than <code><var>randomstring</var>-dnsotls-ds.metric.gstatic.com</code> when the connectivity check mode is set to the default GrapheneOS mode (note: no connection is made to the resolved IP based on the DNS query, this is only used to check if the DNS resolver works and we're mainly changing this for aesthetic reasons)</li>
                         <li>Pixel 6, Pixel 6 Pro, Pixel 6a, Pixel 7, Pixel 7 Pro: switch to more generic broadcom.psds.grapheneos.org name for our Predicted Satellite Data Service (PSDS) cache instead of google.psds.grapheneos.org since we're obtaining it directly from Broadcom rather than Google's cache and it isn't Pixel specific but rather could be used with any Broadcom GNSS (GPS, GLONASS, etc.) chip</li>
                         <li>Dialer: disable showing homescreen wallpaper</li>
@@ -1027,7 +1027,7 @@
                         <li>Sandboxed Google Play compatibility layer: improve handling of activity starts</li>
                         <li>Sandboxed Google Play compatibility layer: bugfix: Parcel position wasn't reset by dynamic stubs</li>
                         <li>Sandboxed Google Play compatibility layer: bugfix: missing handling of ListSlices in dynamic stub</li>
-                        <li>GmsCompatConfig: make sure Play Store PhenotypeFlags are overridable by Gservices flags (further deterring Play Store trying to update Play services / Play Store beyond supported versions)</li>
+                        <li>GmsCompatConfig: make sure Play Store PhenotypeFlags are overridable by Gservices flags (further deterring Play Store trying to update Play services/Play Store beyond supported versions)</li>
                         <li>Pixel 7, Pixel 7 Pro (adevtool): drop unused face unlock components since we have no plans to enable support for an insecure face unlock implementation incapable providing reasonable security due to lack of dedicated face unlock hardware (Pixel 4 and Pixel 4 XL had dual infrared cameras, IR dot projector and IR flood illuminator providing a more secure biometric unlock system than fingerprint unlock as opposed to simply using the front camera in a way that could be done on any device)</li>
                         <li>Pixel 4, Pixel 4 XL, Pixel 4a, Pixel 4a (5G), Pixel 5, Pixel 5a, Pixel 6, Pixel 6 Pro, Pixel 7, Pixel 7 Pro: include gril library to avoid qns crash on Pixel 7 and Pixel 7 Pro</li>
                         <li>Pixel 7, Pixel 7 Pro: include vendor_kernel_boot partition requirement in factory images metadata to force an error with an incompatible fastboot such as the currently buggy Arch Linux package</li>
@@ -1173,7 +1173,7 @@
                         <li>Sandboxed Google Play compatibility layer: add PackageManager.getPackagesForUid() shim</li>
                         <li>Sandboxed Google Play compatibility layer: update link to "Google Location Accuracy" activity to match the style of the Settings app</li>
                         <li>Sandboxed Google Play compatibility layer: add early rejection of getCurrentLocation() requests to avoid unnecessary battery usage and location indicator when we're going to reject the request anyway</li>
-                        <li>Sandboxed Google Play compatibility layer: check request granularity when issuing app-op checks to fix a case where apps can be blamed for doing a fine location check when they only did a coarse location check (no user-facing impact since the location history / indicator makes no distinction and it was correctly enforced for permission enforcement already)</li>
+                        <li>Sandboxed Google Play compatibility layer: check request granularity when issuing app-op checks to fix a case where apps can be blamed for doing a fine location check when they only did a coarse location check (no user-facing impact since the location history/indicator makes no distinction and it was correctly enforced for permission enforcement already)</li>
                     </ul>
                 </article>
 
@@ -1195,7 +1195,7 @@
                         <li>GmsCompatConfig: fix crash in FastPair service</li>
                         <li>kernel (Pixel 6, Pixel 6 Pro, Pixel 6a, Pixel 7, Pixel 7 Pro): update GKI to Linux 5.10.149</li>
                         <li>kernel (Pixel 6, Pixel 6 Pro, Pixel 6a, Pixel 7, Pixel 7 Pro): replace upstream default of sha1 with sha256 for module signing (GKI devices rely on verified boot for vendor modules and only use module signing for GKI modules of which there are currently 0, but it should be using a secure hash in case there are ever GKI modules and for when we extend it to vendor modules as a lower level 2nd layer of security not depending on userspace)</li>
-                        <li>kernel (Pixel 4, Pixel 4 XL, Pixel 4a, Pixel 4a (5G), Pixel 5, Pixel 5a): enable forced kernel module signing with a per-build signing key (RSA 4096 / sha256) as an additional lower level layer of security beyond the verification already provided by dm-verity and SELinux</li>
+                        <li>kernel (Pixel 4, Pixel 4 XL, Pixel 4a, Pixel 4a (5G), Pixel 5, Pixel 5a): enable forced kernel module signing with a per-build signing key (RSA 4096/sha256) as an additional lower level layer of security beyond the verification already provided by dm-verity and SELinux</li>
                         <li>kernel (Pixel 4a, Pixel 4a (5G), Pixel 5, Pixel 5a): disable IP_SCTP</li>
                         <li>kernel (Pixel 4a): enable REFCOUNT_FULL</li>
                         <li>Pixel 7, Pixel 7 Pro: fix bug in detection of the camera service executable for the memory corruption workaround added in the previous release (inconsequential in practice for this specific case of the bug)</li>
@@ -1516,7 +1516,7 @@
                         <li>full 2022-09-05 security patch level</li>
                         <li>rebased onto TP1A.220905.004 release</li>
                         <li>kernel (Pixel 6, Pixel 6 Pro, Pixel 6a): update GKI base to ASB-2022-09-05_13-5.10</li>
-                        <li>kernel (Pixel 6, Pixel 6 Pro, Pixel 6a): split raviole (Pixel 6, Pixel 6 Pro) and bluejay (Pixel 6a) kernels for now due to AOSP / stock OS differences</li>
+                        <li>kernel (Pixel 6, Pixel 6 Pro, Pixel 6a): split raviole (Pixel 6, Pixel 6 Pro) and bluejay (Pixel 6a) kernels for now due to AOSP/stock OS differences</li>
                         <li>fix for Bluetooth timeout feature with BLE devices</li>
                         <li>remove conflicting permission from GSF when parsing the package since it appears to be set incorrectly by a build system bug and conflicts with Shannon IMS on 6th generation Pixels and is blocking us upgrading to GSF v33 via our app repository</li>
                         <li>Vanadium: update Chromium base to 105.0.5195.79</li>
@@ -1700,10 +1700,10 @@
                         <li>drop workaround for slow lockscreen animation which is fixed in Android 13</li>
                         <li>drop workaround for SystemUI ANR (App Not Responding) false positives caused by screenshot service in Android 12</li>
                         <li>Vanadium: revert removal of mremap system call from the sandbox allowlist for now since libc is using it internally</li>
-                        <li>Dialer: temporarily disable R8 optimization to work around missing annotations / exceptions upstream</li>
+                        <li>Dialer: temporarily disable R8 optimization to work around missing annotations/exceptions upstream</li>
                         <li>kernel (Pixel 4, Pixel 4 XL, Pixel 4a, Pixel 4a (5G), Pixel 5, Pixel 5a): switch to kernel manifests instead of including the kernel source trees in the OS source tree with submodules for the module repositories</li>
                         <li>kernel (Pixel 4, Pixel 4 XL, Pixel 4a, Pixel 4a (5G), Pixel 5, Pixel 5a): switch to AOSP kernel build system</li>
-                        <li>kernel (Pixel 4, Pixel 4 XL, Pixel 4a, Pixel 4a (5G), Pixel 5, Pixel 5a): use dynamic kernel modules matching AOSP / stock OS instead of using monolithic kernel builds to avoid further issues from driver bugs with monolithic kernel builds (this was a useful feature but maintenance has become too difficult and the advantages of Generic Kernel Images for 6th generation Pixels and beyond outweigh the benefits so this was already phased out for 6th generation devices)</li>
+                        <li>kernel (Pixel 4, Pixel 4 XL, Pixel 4a, Pixel 4a (5G), Pixel 5, Pixel 5a): use dynamic kernel modules matching AOSP/stock OS instead of using monolithic kernel builds to avoid further issues from driver bugs with monolithic kernel builds (this was a useful feature but maintenance has become too difficult and the advantages of Generic Kernel Images for 6th generation Pixels and beyond outweigh the benefits so this was already phased out for 6th generation devices)</li>
                         <li>kernel (Pixel 6, Pixel 6 Pro, Pixel 6a): temporarily use ThinLTO instead of LTO due to an upstream kernel or toolchain bug we have yet to resolve or work around in a better way</li>
                     </ul>
                 </article>
@@ -1727,7 +1727,7 @@
                     <ul>
                         <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SP1A.210812.016.C2.2022081800">SP1A.210812.016.C2.2022081800</a> (Pixel 3, Pixel 3 XL) — extended support release for legacy devices with frozen 2021-11-01 patch level</li>
                         <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SP2A.220505.006.2022081800">SP2A.220505.006.2022081800</a> (Pixel 3a, Pixel 3a XL) — extended support release for legacy devices with frozen 2022-06-01 patch level</li>
-                        <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SD2A.220601.004.B2.2022081800">SD2A.220601.004.B2.2022081800</a> (Pixel 6a) — early release for Pixel 6a with 2022-06-01 patch level which is the latest available until there's a normal AOSP / stock OS release for it on the latest patch level</li>
+                        <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SD2A.220601.004.B2.2022081800">SD2A.220601.004.B2.2022081800</a> (Pixel 6a) — early release for Pixel 6a with 2022-06-01 patch level which is the latest available until there's a normal AOSP/stock OS release for it on the latest patch level</li>
                         <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SQ3A.220705.003.A1.2022081800">SQ3A.220705.003.A1.2022081800</a> (Pixel 4, Pixel 4 XL, Pixel 4a, Pixel 4a (5G), Pixel 5, Pixel 5a)</li>
                         <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SQ3A.220705.004.2022081800">SQ3A.220705.004.2022081800</a> (Pixel 6, Pixel 6 Pro, emulator, generic, other targets)</li>
                     </ul>
@@ -1746,7 +1746,7 @@
                     <ul>
                         <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SP1A.210812.016.C2.2022081600">SP1A.210812.016.C2.2022081600</a> (Pixel 3, Pixel 3 XL) — extended support release for legacy devices with frozen 2021-11-01 patch level</li>
                         <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SP2A.220505.006.2022081600">SP2A.220505.006.2022081600</a> (Pixel 3a, Pixel 3a XL) — extended support release for legacy devices with frozen 2022-06-01 patch level</li>
-                        <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SD2A.220601.004.B2.2022081600">SD2A.220601.004.B2.2022081600</a> (Pixel 6a) — early release for Pixel 6a with 2022-06-01 patch level which is the latest available until there's a normal AOSP / stock OS release for it on the latest patch level</li>
+                        <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SD2A.220601.004.B2.2022081600">SD2A.220601.004.B2.2022081600</a> (Pixel 6a) — early release for Pixel 6a with 2022-06-01 patch level which is the latest available until there's a normal AOSP/stock OS release for it on the latest patch level</li>
                         <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SQ3A.220705.003.A1.2022081600">SQ3A.220705.003.A1.2022081600</a> (Pixel 4, Pixel 4 XL, Pixel 4a, Pixel 4a (5G), Pixel 5, Pixel 5a)</li>
                         <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SQ3A.220705.004.2022081600">SQ3A.220705.004.2022081600</a> (Pixel 6, Pixel 6 Pro, emulator, generic, other targets)</li>
                     </ul>
@@ -1759,7 +1759,7 @@
                         <li>Vanadium: backport using Android 13 SDK and changes to support using Android 13</li>
                         <li>Vanadium: update Chromium base to 104.0.5112.97</li>
                         <li>Vanadium: restore previous launcher icon</li>
-                        <li>Pixel 6a: switch to SD2A.220601.004.B2 (July 2022) device sources and vendor files (AOSP / stock OS patch level for Pixel 6a is still 2022-06-01 until Android 13)</li>
+                        <li>Pixel 6a: switch to SD2A.220601.004.B2 (July 2022) device sources and vendor files (AOSP/stock OS patch level for Pixel 6a is still 2022-06-01 until Android 13)</li>
                     </ul>
                 </article>
 
@@ -1770,7 +1770,7 @@
                     <ul>
                         <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SP1A.210812.016.C2.2022080900">SP1A.210812.016.C2.2022080900</a> (Pixel 3, Pixel 3 XL) — extended support release for legacy devices with frozen 2021-11-01 patch level</li>
                         <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SP2A.220505.006.2022080900">SP2A.220505.006.2022080900</a> (Pixel 3a, Pixel 3a XL) — extended support release for legacy devices with frozen 2022-06-01 patch level</li>
-                        <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SD2A.220601.004.2022080900">SD2A.220601.004.2022080900</a> (Pixel 6a) — early release for Pixel 6a with 2022-06-01 patch level which is the latest available until there's a normal AOSP / stock OS release for it on the latest patch level</li>
+                        <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SD2A.220601.004.2022080900">SD2A.220601.004.2022080900</a> (Pixel 6a) — early release for Pixel 6a with 2022-06-01 patch level which is the latest available until there's a normal AOSP/stock OS release for it on the latest patch level</li>
                         <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SQ3A.220705.003.A1.2022080900">SQ3A.220705.003.A1.2022080900</a> (Pixel 4, Pixel 4 XL, Pixel 4a, Pixel 4a (5G), Pixel 5, Pixel 5a)</li>
                         <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SQ3A.220705.004.2022080900">SQ3A.220705.004.2022080900</a> (Pixel 6, Pixel 6 Pro, emulator, generic, other targets)</li>
                     </ul>
@@ -1783,7 +1783,7 @@
                         <li>Sandboxed Google Play compatibility layer: stub out getPrivilegedConfiguredNetworks() to fix sharing Wi-Fi credentials with a WearOS device and other features</li>
                         <li>Sandboxed Google Play compatibility layer: add workaround for another power exemption whitelist use tied to WearOS</li>
                         <li>Sandboxed Google Play compatibility layer: notify the user about GMS crashes</li>
-                        <li>Sandboxed Google Play compatibility layer: improved robust / future proofing</li>
+                        <li>Sandboxed Google Play compatibility layer: improved robust/future proofing</li>
                         <li>Sandboxed Google Play compatibility layer: add support for installing Google Chrome via Play Store via the unprivileged package installation API by safely breaking up the multi-package session</li>
                         <li>Sandboxed Google Play compatibility layer: improve compatibility with Nearby Share</li>
                         <li>exec spawning: don't close binder connection when an app crashes to fix debugging features including the crash dialog</li>
@@ -1797,7 +1797,7 @@
                     <ul>
                         <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SP1A.210812.016.C2.2022080500">SP1A.210812.016.C2.2022080500</a> (Pixel 3, Pixel 3 XL) — extended support release for legacy devices with frozen 2021-11-01 patch level</li>
                         <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SP2A.220505.006.2022080500">SP2A.220505.006.2022080500</a> (Pixel 3a, Pixel 3a XL) — extended support release for legacy devices with frozen 2022-06-01 patch level</li>
-                        <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SD2A.220601.004.2022080500">SD2A.220601.004.2022080500</a> (Pixel 6a) — early release for Pixel 6a with 2022-06-01 patch level which is the latest available until there's a normal AOSP / stock OS release for it on the latest patch level</li>
+                        <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SD2A.220601.004.2022080500">SD2A.220601.004.2022080500</a> (Pixel 6a) — early release for Pixel 6a with 2022-06-01 patch level which is the latest available until there's a normal AOSP/stock OS release for it on the latest patch level</li>
                         <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SQ3A.220705.003.A1.2022080500">SQ3A.220705.003.A1.2022080500</a> (Pixel 4, Pixel 4 XL, Pixel 4a, Pixel 4a (5G), Pixel 5, Pixel 5a)</li>
                         <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SQ3A.220705.004.2022080500">SQ3A.220705.004.2022080500</a> (Pixel 6, Pixel 6 Pro, emulator, generic, other targets)</li>
                     </ul>
@@ -1819,7 +1819,7 @@
                     <ul>
                         <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SP1A.210812.016.C2.2022080300">SP1A.210812.016.C2.2022080300</a> (Pixel 3, Pixel 3 XL) — extended support release for legacy devices with frozen 2021-11-01 patch level</li>
                         <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SP2A.220505.006.2022080300">SP2A.220505.006.2022080300</a> (Pixel 3a, Pixel 3a XL) — extended support release for legacy devices with frozen 2022-06-01 patch level</li>
-                        <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SD2A.220601.004.2022080300">SD2A.220601.004.2022080300</a> (Pixel 6a) — early release for Pixel 6a with 2022-06-01 patch level which is the latest available until there's a normal AOSP / stock OS release for it on the latest patch level</li>
+                        <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SD2A.220601.004.2022080300">SD2A.220601.004.2022080300</a> (Pixel 6a) — early release for Pixel 6a with 2022-06-01 patch level which is the latest available until there's a normal AOSP/stock OS release for it on the latest patch level</li>
                         <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SQ3A.220705.003.A1.2022080300">SQ3A.220705.003.A1.2022080300</a> (Pixel 4, Pixel 4 XL, Pixel 4a, Pixel 4a (5G), Pixel 5, Pixel 5a, Pixel 6, Pixel 6 Pro, emulator, generic, other targets)</li>
                     </ul>
 
@@ -1843,7 +1843,7 @@
                     <ul>
                         <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SP1A.210812.016.C2.2022073000">SP1A.210812.016.C2.2022073000</a> (Pixel 3, Pixel 3 XL) — extended support release for legacy devices with frozen 2021-11-01 patch level</li>
                         <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SP2A.220505.006.2022073000">SP2A.220505.006.2022073000</a> (Pixel 3a, Pixel 3a XL) — extended support release for legacy devices with frozen 2022-06-01 patch level</li>
-                        <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SD2A.220601.004.2022073000">SD2A.220601.004.2022073000</a> (Pixel 6a) — early release for Pixel 6a with 2022-06-01 patch level which is the latest available until there's a normal AOSP / stock OS release for it on the latest patch level</li>
+                        <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SD2A.220601.004.2022073000">SD2A.220601.004.2022073000</a> (Pixel 6a) — early release for Pixel 6a with 2022-06-01 patch level which is the latest available until there's a normal AOSP/stock OS release for it on the latest patch level</li>
                         <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SQ3A.220705.003.A1.2022073000">SQ3A.220705.003.A1.2022073000</a> (Pixel 4, Pixel 4 XL, Pixel 4a, Pixel 4a (5G), Pixel 5, Pixel 5a, Pixel 6, Pixel 6 Pro, emulator, generic, other targets)</li>
                     </ul>
 
@@ -1956,7 +1956,7 @@
                     <p>Changes since the 2022070600 release:</p>
 
                     <ul>
-                        <li>add new Storage Scopes feature for granting limited access to shared storage for apps normally requiring granting the storage permission (Files and Media for legacy apps, Media for modern apps), the file management special access permission (All files access) or the media management special access permission where these apps will think they've been granted those permissions but will only have access to specific scopes you've chosen to grant to them, as if they supported granting case-by-case consent through the system file manager themselves (which is not impacted by this feature and you can still grant case-by-case access to any file / directory through it)</li>
+                        <li>add new Storage Scopes feature for granting limited access to shared storage for apps normally requiring granting the storage permission (Files and Media for legacy apps, Media for modern apps), the file management special access permission (All files access) or the media management special access permission where these apps will think they've been granted those permissions but will only have access to specific scopes you've chosen to grant to them, as if they supported granting case-by-case consent through the system file manager themselves (which is not impacted by this feature and you can still grant case-by-case access to any file/directory through it)</li>
                         <li>split out a new toggle for OBB (Opaque Binary Blob) installation (legacy approach to distributing large assets primarily used by games) so that the Play Store and other app stores with asset delivery support can be granted OBB access instead of Media access (or Files and Media for legacy apps)</li>
                         <li>fix upstream Android bug in DeviceIdleJobsController which was preventing battery optimization exceptions from fully working for system apps and resulting in delays in some cases for the Messaging app and other system apps</li>
                         <li>respect user switchability for forwarded notification UI</li>
@@ -2053,7 +2053,7 @@
                         <li>add indicator exemption for OS cell broadcast service which uses location services to determine if alerts should be shown</li>
                         <li>Pixel 3, Pixel 3 XL, Pixel 3a, Pixel 3a XL: update end-of-life kernel source tree with backported patches</li>
                         <li>enable always-on VPN and lockdown mode by default when adding a VPN</li>
-                        <li>add warning notification about insecure prototype Pixel devices since users are ending up getting prototype phones second hand that were stolen or sold by employees instead of returning / disposing of them (this is of course much more robustly detected by Auditor for users verifying with it)</li>
+                        <li>add warning notification about insecure prototype Pixel devices since users are ending up getting prototype phones second hand that were stolen or sold by employees instead of returning/disposing of them (this is of course much more robustly detected by Auditor for users verifying with it)</li>
                         <li>Pixel 4a (5G), Pixel 5, Pixel 5a: update kernel build tools revision</li>
                     </ul>
                 </article>
@@ -2301,7 +2301,7 @@
                         <li>remove build fingerprint from screenshot EXIF metadata</li>
                         <li>Vanadium: update Chromium base to 101.0.4951.41</li>
                         <li>carriersettings-extractor: reuse protocol buffer definitions from AOSP and improve code quality</li>
-                        <li>System Updater: add user-facing Alpha channel for very basic / quick public testing after our internal testing before we release to the Beta channel</li>
+                        <li>System Updater: add user-facing Alpha channel for very basic/quick public testing after our internal testing before we release to the Beta channel</li>
                         <li>Pixel 4, Pixel 4 XL, Pixel 4a, Pixel 4a (5G), Pixel 5, Pixel 5a, Pixel 6, Pixel 6 Pro: stop declaring next generation assistant support as an included feature</li>
                         <li>Camera: update to <a href="https://github.com/GrapheneOS/Camera/releases/tag/25">version 25</a></li>
                         <li>Camera: update to <a href="https://github.com/GrapheneOS/Camera/releases/tag/26">version 26</a></li>
@@ -2486,7 +2486,7 @@
                         <li>backport fix for crash in telephony service with null subscription display name</li>
                         <li>backport Wi-Fi APEX module fix to improve robustness when chip reconfiguration fails</li>
                         <li>Settings: improve title/summary for attestation key provisioning server</li>
-                        <li>Pixel 3, Pixel 3 XL: fix hardware-based attestation by rolling back an Android 12.1 change for these devices depending on updates to the firmware / device support code since these are end-of-life devices and don't receive those updates so it broke attestation support</li>
+                        <li>Pixel 3, Pixel 3 XL: fix hardware-based attestation by rolling back an Android 12.1 change for these devices depending on updates to the firmware/device support code since these are end-of-life devices and don't receive those updates so it broke attestation support</li>
                         <li>Camera: update to <a href="https://github.com/GrapheneOS/Camera/releases/tag/18">version 18</a></li>
                         <li>Vanadium: update Chromium base to 100.0.4896.79</li>
                         <li>TalkBack (screen reader): dependency updates and crash fix</li>
@@ -2544,7 +2544,7 @@
                         <li>Camera: update to <a href="https://github.com/GrapheneOS/Camera/releases/tag/17">version 17</a></li>
                         <li>Pixel 3, Pixel 3 XL, Pixel 3a, Pixel 3a XL, Pixel 4, Pixel 4 XL, Pixel 4a, Pixel 4a (5G), Pixel 5, Pixel 5a, Pixel 6, Pixel 6 Pro: remove unnecessary configuration/permissions for apps not included in AOSP/GrapheneOS</li>
                         <li>Pixel 3, Pixel 3 XL, Pixel 3a, Pixel 3a XL, Pixel 4, Pixel 4 XL, Pixel 4a, Pixel 4a (5G), Pixel 5, Pixel 5a, Pixel 6, Pixel 6 Pro: add RCS packages</li>
-                        <li>Pixel 3, Pixel 3 XL, Pixel 3a, Pixel 3a XL, Pixel 4, Pixel 4 XL, Pixel 4a, Pixel 4a (5G), Pixel 5, Pixel 5a, Pixel 6, Pixel 6 Pro: remove AOSP / stock OS configuration pinning the system camera and launcher in memory since it's wasteful</li>
+                        <li>Pixel 3, Pixel 3 XL, Pixel 3a, Pixel 3a XL, Pixel 4, Pixel 4 XL, Pixel 4a, Pixel 4a (5G), Pixel 5, Pixel 5a, Pixel 6, Pixel 6 Pro: remove AOSP/stock OS configuration pinning the system camera and launcher in memory since it's wasteful</li>
                         <li>Pixel 3, Pixel 3 XL, Pixel 3a, Pixel 3a XL, Pixel 4, Pixel 4 XL, Pixel 4a, Pixel 4a (5G), Pixel 5, Pixel 5a, Pixel 6, Pixel 6 Pro: stop forcing camera shutter sound on the Japanese hardware SKUs</li>
                     </ul>
                 </article>
@@ -2564,7 +2564,7 @@
                     <ul>
                         <li>Pixel 6, Pixel 6 Pro: full Pixel 2022-03-05 security patch level (Android 2022-03-05 security patch level was already provided early by GrapheneOS)</li>
                         <li>Pixel 6, Pixel 6 Pro: rebased onto SP2A.220305.013.A3 release</li>
-                        <li>kernel (Pixel 6, Pixel 6 Pro): update GKI base to android12-5.10-2021-12_r8 from the android12-5.10-2021-12_r6 version still used by the AOSP / stock Pixel OS March release for a few additional security fixes beyond the ones already backported early by GrapheneOS along with latency improvements under certain heavy real-time loads</li>
+                        <li>kernel (Pixel 6, Pixel 6 Pro): update GKI base to android12-5.10-2021-12_r8 from the android12-5.10-2021-12_r6 version still used by the AOSP/stock Pixel OS March release for a few additional security fixes beyond the ones already backported early by GrapheneOS along with latency improvements under certain heavy real-time loads</li>
                         <li>add eSIM activation support as an optional toggle available when using sandboxed Google Play in the Owner profile (note: regular apps including sandboxed Google Play do not have additional access in the Owner profile)</li>
                         <li>Sandboxed Google Play compatibility layer: expand PhenoTypeFlags workaround to all Play services clients</li>
                         <li>GmsCompat: call startForegroundService from the main thread to avoid potential issues</li>
@@ -2708,7 +2708,7 @@
                         <li>PDF Viewer: update to <a href="https://github.com/GrapheneOS/PdfViewer/releases/tag/12">version 12</a></li>
                         <li>Contacts: add support for vCard 4.0</li>
                         <li>Pixel 3, Pixel 3 XL, Pixel 3a, Pixel 3a XL, Pixel 4, Pixel 4 XL, Pixel 4a, Pixel 4a (5G), Pixel 5, Pixel 5a, Pixel 6, Pixel 6 Pro: include current eSIM firmware, EuiccPixel and EuiccPixel integration (this improves eSIM support by keeping the eSIM firmware up-to-date but does not provide eSIM activation yet)</li>
-                        <li>Sandboxed Google Play compatibility layer: improve code quality / robustness</li>
+                        <li>Sandboxed Google Play compatibility layer: improve code quality/robustness</li>
                         <li>mark Bluetooth service as an extra location package to avoid showing misleading/unhelpful location indicators (Bluetooth scanning is considered location access for apps, but it makes no sense to show it for the Bluetooth implementation itself rather than only actual apps using it)</li>
                         <li>Pixel 6, Pixel 6 Pro: mark Shannon IMS service as an extra location package to avoid showing unhelpful location indicators (it retrieves location information regularly in order to have it ready for an emergency call)</li>
                     </ul>
@@ -2750,7 +2750,7 @@
                         <li>Sandboxed Google Play compatibility layer: update dynamite module compatibility layer for upcoming changes to Play services</li>
                         <li>Sandboxed Google Play compatibility layer: friendlier error for apps without Location permission attempting to use redirected Play services geolocation to match Play services behavior</li>
                         <li>Vanadium: update Chromium base to 98.0.4758.101</li>
-                        <li>cancel pending over-the-air update snapshot when flashing factory images via flash-all.sh / flash-all.bat</li>
+                        <li>cancel pending over-the-air update snapshot when flashing factory images via flash-all.sh/flash-all.bat</li>
                         <li>Pixel 6, Pixel 6 Pro: add missing camera shutter sound change from the <a href="#2022021314">2022021314 release</a></li>
                     </ul>
                 </article>
@@ -2962,7 +2962,7 @@
                     <ul>
                         <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SP1A.210812.015.2022010500">SP1A.210812.015.2022010500</a> (Pixel 3, Pixel 3 XL) — extended support release for legacy devices with frozen 2021-11-01 patch level</li>
                         <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SQ1A.220105.002.2022010500">SQ1A.220105.002.2022010500</a> (Pixel 3a, Pixel 3a XL, Pixel 4, Pixel 4 XL, Pixel 4a, Pixel 4a (5G), Pixel 5, Pixel 5a, emulator, generic, other targets)</li>
-                        <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SQ1D.211205.017.2022010500">SQ1D.211205.017.2022010500</a> (Pixel 6, Pixel 6 Pro) — early release with the full Android 2022-01-05 patch level but only the 2022-01-01 Pixel patch level since the AOSP / stock OS January update for the Pixel 6 and Pixel 6 Pro is happening in late January so the patches specific to them aren't publicly available yet</li>
+                        <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SQ1D.211205.017.2022010500">SQ1D.211205.017.2022010500</a> (Pixel 6, Pixel 6 Pro) — early release with the full Android 2022-01-05 patch level but only the 2022-01-01 Pixel patch level since the AOSP/stock OS January update for the Pixel 6 and Pixel 6 Pro is happening in late January so the patches specific to them aren't publicly available yet</li>
                     </ul>
 
                     <p>Changes since the 2021122018 release:</p>
@@ -3297,7 +3297,7 @@
                     <ul>
                         <li>Settings: add back reset text change lost in the port to Android 12</li>
                         <li>fix inclusion of up-to-date per-device APN database for Pixels</li>
-                        <li>Pixel 4a: fix build system issue causing device specific APN / carrier configuration to be omitted</li>
+                        <li>Pixel 4a: fix build system issue causing device specific APN/carrier configuration to be omitted</li>
                         <li>support using the legacy wifi/cellular quick tiles (combined internet quick tile will still be used by default)</li>
                         <li>Dialer: improve swipe to accept/reject calls</li>
                         <li>Dialer: fix issue with USB headset audio routing</li>
@@ -3418,7 +3418,7 @@
                         <li>Vanadium: update Chromium base to 94.0.4606.71</li>
                         <li>change generated carrier configurations to always allow editing APNs</li>
                         <li>always show APN settings on CDMA carriers</li>
-                        <li>automate APN / carrier settings updates</li>
+                        <li>automate APN/carrier settings updates</li>
                     </ul>
                 </article>
 
@@ -3436,7 +3436,7 @@
                     <ul>
                         <li>kernel (Pixel 3, Pixel 3 XL, Pixel 3a, Pixel 3a XL): apply upstream fix for ION use-after-free vulnerability</li>
                         <li>Vanadium: update Chromium base to 94.0.4606.61</li>
-                        <li>android-prepare-vendor: remove a bunch of unused code / functionality</li>
+                        <li>android-prepare-vendor: remove a bunch of unused code/functionality</li>
                         <li>android-prepare-vendor: skip all kernel modules</li>
                     </ul>
                 </article>
@@ -3609,7 +3609,7 @@
                     <p>Changes since the 2021.08.03.03 release:</p>
 
                     <ul>
-                        <li>Sandboxed Google Play compatibility layer: add infrastructure / shims to support dynamite modules (dynamically loaded modules including Maps API support)</li>
+                        <li>Sandboxed Google Play compatibility layer: add infrastructure/shims to support dynamite modules (dynamically loaded modules including Maps API support)</li>
                         <li>Vanadium: update Chromium base to 92.0.4515.131</li>
                         <li>Vanadium: disable trials of privacy-aware analytics/advertising APIs</li>
                         <li>Vanadium: remove unwanted sync and services link</li>
@@ -3656,7 +3656,7 @@
                     <p>Changes since the 2021.07.19.18 release:</p>
 
                     <ul>
-                        <li>System Updater: add detailed failure / success notifications. The next release will enable the timestamp to show when it happened. You can turn off the 'Already Updated' notification channel if you don't want those minimum priority notifications with no status icon collapsed at the bottom.</li>
+                        <li>System Updater: add detailed failure/success notifications. The next release will enable the timestamp to show when it happened. You can turn off the 'Already Updated' notification channel if you don't want those minimum priority notifications with no status icon collapsed at the bottom.</li>
                         <li>Vanadium: update Chromium base to 92.0.4515.105</li>
                         <li>Vanadium: update Chromium base to 92.0.4515.115</li>
                         <li>Vanadium: drop removal of speculative service worker start for search</li>
@@ -3895,7 +3895,7 @@
                         <li>integrate modern Android theme and wallpaper configuration</li>
                         <li>remove legacy WallpaperPicker app</li>
                         <li>System Updater: modernize update settings via androidx preference library (new theme has minor quirks we'll be fixing in the next release)</li>
-                        <li>use alternate grapheneos.online domain for connectivity check / captive portal fallback URLs to improve handling of future issues comparable to Quad9 temporarily blocking grapheneos.network due to some kind of false positive</li>
+                        <li>use alternate grapheneos.online domain for connectivity check/captive portal fallback URLs to improve handling of future issues comparable to Quad9 temporarily blocking grapheneos.network due to some kind of false positive</li>
                         <li>Pixel 3, Pixel 3 XL, Pixel 3a, Pixel 3a XL, Pixel 4, Pixel 4 XL, Pixel 4a, Pixel 4a (5G), Pixel 5: update APNs</li>
                         <li>Pixel 3, Pixel 3 XL, Pixel 3a, Pixel 3a XL, Pixel 4, Pixel 4 XL, Pixel 4a, Pixel 4a (5G), Pixel 5: update CarrierConfig vendor.xml</li>
                     </ul>
@@ -4029,7 +4029,7 @@
                         <li>Vanadium: disable building code as dynamic feature modules</li>
                         <li>kernel (Pixel 4a): fix techpack/audio build reproducibility issue</li>
                         <li>backport upstream fix for building on compressed filesystems</li>
-                        <li>Calendar: remove launcher icon since the app exists for compatibility / testing</li>
+                        <li>Calendar: remove launcher icon since the app exists for compatibility/testing</li>
                         <li>Seedvault: update to latest revision</li>
                     </ul>
                 </article>
@@ -4519,7 +4519,7 @@
                     <p>Changes since the 2020.09.11.14 release:</p>
 
                     <ul>
-                        <li>initial port to Android 11 with most GrapheneOS changes ported over (missing most SELinux policy hardening, some Pixel 4 / 4 XL kernel side channel mitigations, finer-grained Pixel 4 kernel Control Flow Integrity and the setup wizard)</li>
+                        <li>initial port to Android 11 with most GrapheneOS changes ported over (missing most SELinux policy hardening, some Pixel 4/4 XL kernel side channel mitigations, finer-grained Pixel 4 kernel Control Flow Integrity and the setup wizard)</li>
                         <li>full 2020-09-05 security patch level</li>
                         <li>temporarily use stock WebView until the next release of Chromium is available with public support for Android 11 to provide the WebView via Vanadium again</li>
                         <li>fix VPN lockdown setting getting overridden on user stop</li>
@@ -4705,7 +4705,7 @@
                         <li>System Updater: sanity check channel name in update channel metadata</li>
                         <li>System Updater: raise minSdkVersion to 29</li>
                         <li>System Updater: extract care_map.pb rather than care_map.txt</li>
-                        <li>System Updater: use a different zip for streaming updates (still an experimental / hidden feature)</li>
+                        <li>System Updater: use a different zip for streaming updates (still an experimental/hidden feature)</li>
                         <li>disable RFC 7217 support (stable link-local IPv6 privacy addresses) and stick to link-local IP addresses based on the (random) MAC addresses</li>
                         <li>SetupWizard: update to latest upstream code</li>
                         <li>SetupWizard: use system captive portal URL, rather than a custom Google URL</li>
@@ -4896,7 +4896,7 @@
                         <li>Vanadium: update Chromium base to 80.0.3987.162</li>
                         <li>PDF Viewer: update to <a href="https://github.com/GrapheneOS/PdfViewer/releases/tag/3">version 3</a></li>
                         <li>update SELinux policy for officially supported devices based on isolated_app domain split</li>
-                        <li>raise protected_fifos / protected_regular from 1 (world-writable directories) to 2 (group-writable directories too)</li>
+                        <li>raise protected_fifos/protected_regular from 1 (world-writable directories) to 2 (group-writable directories too)</li>
                         <li>remove use of "Hey Google" as an example feature for battery saver in Settings</li>
                     </ul>
                 </article>
@@ -5145,7 +5145,7 @@
                         <li>WebView: update to 78.0.3904.90</li>
                         <li>kernel (Pixel 3, Pixel 3 XL, Pixel 3a, Pixel 3a XL): mark functions with address taken via assembly (this fixes compatibility with CFI in a build with !CONFIG_MODULES)</li>
                         <li>protect static TLS from stack buffer overflows</li>
-                        <li>drop legacy Pixel and Pixel XL support due to absence of any GrapheneOS device maintainers, the end of vendor support and an increasingly large security gap with current generation devices for the hardware, firmware and device / generation specific software</li>
+                        <li>drop legacy Pixel and Pixel XL support due to absence of any GrapheneOS device maintainers, the end of vendor support and an increasingly large security gap with current generation devices for the hardware, firmware and device/generation specific software</li>
                     </ul>
 
                     <p>Restoration of past features since the 2019.09.25.00 release:</p>
@@ -5184,7 +5184,7 @@
                     <p>Restoration of past features since the 2019.09.25.00 release:</p>
 
                     <ul>
-                        <li>begin generating / uploading delta updates from the last release to the current release</li>
+                        <li>begin generating/uploading delta updates from the last release to the current release</li>
                     </ul>
                 </article>
 
@@ -5296,8 +5296,8 @@
                         <li>add Vanadium to the apps that cannot be disabled via Settings (can still be disabled) since the warning isn't enough to deter people from unknowingly breaking apps using the WebView</li>
                         <li>System Updater: add settings entry to manually trigger check for updates</li>
                         <li>System Updater: reschedule update check job on channel change</li>
-                        <li>arm, x86 and x86_64 are now supported / tested architectures</li>
-                        <li>generic and emulator build targets are now supported / tested for development usage (not suitable for secure production releases)</li>
+                        <li>arm, x86 and x86_64 are now supported/tested architectures</li>
+                        <li>generic and emulator build targets are now supported/tested for development usage (not suitable for secure production releases)</li>
                     </ul>
                 </article>
 
@@ -5350,7 +5350,7 @@
                         <li>Vanadium: disable media router media remoting by default</li>
                         <li>Vanadium: disable media router by default (avoids the triggering warning about not having Play services)</li>
                         <li>Vanadium: remove Help &amp; feedback menu entry</li>
-                        <li>Vanadium: further string rebranding from Chromium / Chrome to Vanadium</li>
+                        <li>Vanadium: further string rebranding from Chromium/Chrome to Vanadium</li>
                         <li>Vanadium: disable unused reporting feature at compile-time</li>
                         <li>Vanadium: disable unused remoting feature at compile-time</li>
                         <li>Vanadium (browser and WebView): move from external/chromium to external/vanadium in the GrapheneOS source tree and rename module from Chromium to Vanadium</li>
@@ -5438,7 +5438,7 @@
                     <p>Changes since the 2019.06.14.02 release:</p>
 
                     <ul>
-                        <li>hardened_malloc: use copy_size to check for canaries (tiny performance / hardening fix and avoids an erroneous abort in a corner case with realloc from 0 byte allocations)</li>
+                        <li>hardened_malloc: use copy_size to check for canaries (tiny performance/hardening fix and avoids an erroneous abort in a corner case with realloc from 0 byte allocations)</li>
                         <li>hardened_malloc: update libdivide to 1.1</li>
                         <li>Pixel 3a, Pixel 3a XL: raise maximum users to 16</li>
                         <li>Pixel 3a, Pixel 3a XL: disable system_other odex</li>

--- a/static/releases.html
+++ b/static/releases.html
@@ -1027,7 +1027,7 @@
                         <li>Sandboxed Google Play compatibility layer: improve handling of activity starts</li>
                         <li>Sandboxed Google Play compatibility layer: bugfix: Parcel position wasn't reset by dynamic stubs</li>
                         <li>Sandboxed Google Play compatibility layer: bugfix: missing handling of ListSlices in dynamic stub</li>
-                        <li>GmsCompatConfig: make sure Play Store PhenotypeFlags are overridable by Gservices flags (further deterring Play Store trying to update Play services/Play Store beyond supported versions)</li>
+                        <li>GmsCompatConfig: make sure Play Store PhenotypeFlags are overridable by Gservices flags (further deterring Play Store trying to update Play services / Play Store beyond supported versions)</li>
                         <li>Pixel 7, Pixel 7 Pro (adevtool): drop unused face unlock components since we have no plans to enable support for an insecure face unlock implementation incapable providing reasonable security due to lack of dedicated face unlock hardware (Pixel 4 and Pixel 4 XL had dual infrared cameras, IR dot projector and IR flood illuminator providing a more secure biometric unlock system than fingerprint unlock as opposed to simply using the front camera in a way that could be done on any device)</li>
                         <li>Pixel 4, Pixel 4 XL, Pixel 4a, Pixel 4a (5G), Pixel 5, Pixel 5a, Pixel 6, Pixel 6 Pro, Pixel 7, Pixel 7 Pro: include gril library to avoid qns crash on Pixel 7 and Pixel 7 Pro</li>
                         <li>Pixel 7, Pixel 7 Pro: include vendor_kernel_boot partition requirement in factory images metadata to force an error with an incompatible fastboot such as the currently buggy Arch Linux package</li>
@@ -1195,7 +1195,7 @@
                         <li>GmsCompatConfig: fix crash in FastPair service</li>
                         <li>kernel (Pixel 6, Pixel 6 Pro, Pixel 6a, Pixel 7, Pixel 7 Pro): update GKI to Linux 5.10.149</li>
                         <li>kernel (Pixel 6, Pixel 6 Pro, Pixel 6a, Pixel 7, Pixel 7 Pro): replace upstream default of sha1 with sha256 for module signing (GKI devices rely on verified boot for vendor modules and only use module signing for GKI modules of which there are currently 0, but it should be using a secure hash in case there are ever GKI modules and for when we extend it to vendor modules as a lower level 2nd layer of security not depending on userspace)</li>
-                        <li>kernel (Pixel 4, Pixel 4 XL, Pixel 4a, Pixel 4a (5G), Pixel 5, Pixel 5a): enable forced kernel module signing with a per-build signing key (RSA 4096/sha256) as an additional lower level layer of security beyond the verification already provided by dm-verity and SELinux</li>
+                        <li>kernel (Pixel 4, Pixel 4 XL, Pixel 4a, Pixel 4a (5G), Pixel 5, Pixel 5a): enable forced kernel module signing with a per-build signing key (RSA 4096 / sha256) as an additional lower level layer of security beyond the verification already provided by dm-verity and SELinux</li>
                         <li>kernel (Pixel 4a, Pixel 4a (5G), Pixel 5, Pixel 5a): disable IP_SCTP</li>
                         <li>kernel (Pixel 4a): enable REFCOUNT_FULL</li>
                         <li>Pixel 7, Pixel 7 Pro: fix bug in detection of the camera service executable for the memory corruption workaround added in the previous release (inconsequential in practice for this specific case of the bug)</li>
@@ -1516,7 +1516,7 @@
                         <li>full 2022-09-05 security patch level</li>
                         <li>rebased onto TP1A.220905.004 release</li>
                         <li>kernel (Pixel 6, Pixel 6 Pro, Pixel 6a): update GKI base to ASB-2022-09-05_13-5.10</li>
-                        <li>kernel (Pixel 6, Pixel 6 Pro, Pixel 6a): split raviole (Pixel 6, Pixel 6 Pro) and bluejay (Pixel 6a) kernels for now due to AOSP/stock OS differences</li>
+                        <li>kernel (Pixel 6, Pixel 6 Pro, Pixel 6a): split raviole (Pixel 6, Pixel 6 Pro) and bluejay (Pixel 6a) kernels for now due to AOSP / stock OS differences</li>
                         <li>fix for Bluetooth timeout feature with BLE devices</li>
                         <li>remove conflicting permission from GSF when parsing the package since it appears to be set incorrectly by a build system bug and conflicts with Shannon IMS on 6th generation Pixels and is blocking us upgrading to GSF v33 via our app repository</li>
                         <li>Vanadium: update Chromium base to 105.0.5195.79</li>
@@ -1703,7 +1703,7 @@
                         <li>Dialer: temporarily disable R8 optimization to work around missing annotations/exceptions upstream</li>
                         <li>kernel (Pixel 4, Pixel 4 XL, Pixel 4a, Pixel 4a (5G), Pixel 5, Pixel 5a): switch to kernel manifests instead of including the kernel source trees in the OS source tree with submodules for the module repositories</li>
                         <li>kernel (Pixel 4, Pixel 4 XL, Pixel 4a, Pixel 4a (5G), Pixel 5, Pixel 5a): switch to AOSP kernel build system</li>
-                        <li>kernel (Pixel 4, Pixel 4 XL, Pixel 4a, Pixel 4a (5G), Pixel 5, Pixel 5a): use dynamic kernel modules matching AOSP/stock OS instead of using monolithic kernel builds to avoid further issues from driver bugs with monolithic kernel builds (this was a useful feature but maintenance has become too difficult and the advantages of Generic Kernel Images for 6th generation Pixels and beyond outweigh the benefits so this was already phased out for 6th generation devices)</li>
+                        <li>kernel (Pixel 4, Pixel 4 XL, Pixel 4a, Pixel 4a (5G), Pixel 5, Pixel 5a): use dynamic kernel modules matching AOSP / stock OS instead of using monolithic kernel builds to avoid further issues from driver bugs with monolithic kernel builds (this was a useful feature but maintenance has become too difficult and the advantages of Generic Kernel Images for 6th generation Pixels and beyond outweigh the benefits so this was already phased out for 6th generation devices)</li>
                         <li>kernel (Pixel 6, Pixel 6 Pro, Pixel 6a): temporarily use ThinLTO instead of LTO due to an upstream kernel or toolchain bug we have yet to resolve or work around in a better way</li>
                     </ul>
                 </article>
@@ -1727,7 +1727,7 @@
                     <ul>
                         <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SP1A.210812.016.C2.2022081800">SP1A.210812.016.C2.2022081800</a> (Pixel 3, Pixel 3 XL) — extended support release for legacy devices with frozen 2021-11-01 patch level</li>
                         <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SP2A.220505.006.2022081800">SP2A.220505.006.2022081800</a> (Pixel 3a, Pixel 3a XL) — extended support release for legacy devices with frozen 2022-06-01 patch level</li>
-                        <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SD2A.220601.004.B2.2022081800">SD2A.220601.004.B2.2022081800</a> (Pixel 6a) — early release for Pixel 6a with 2022-06-01 patch level which is the latest available until there's a normal AOSP/stock OS release for it on the latest patch level</li>
+                        <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SD2A.220601.004.B2.2022081800">SD2A.220601.004.B2.2022081800</a> (Pixel 6a) — early release for Pixel 6a with 2022-06-01 patch level which is the latest available until there's a normal AOSP / stock OS release for it on the latest patch level</li>
                         <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SQ3A.220705.003.A1.2022081800">SQ3A.220705.003.A1.2022081800</a> (Pixel 4, Pixel 4 XL, Pixel 4a, Pixel 4a (5G), Pixel 5, Pixel 5a)</li>
                         <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SQ3A.220705.004.2022081800">SQ3A.220705.004.2022081800</a> (Pixel 6, Pixel 6 Pro, emulator, generic, other targets)</li>
                     </ul>
@@ -1746,7 +1746,7 @@
                     <ul>
                         <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SP1A.210812.016.C2.2022081600">SP1A.210812.016.C2.2022081600</a> (Pixel 3, Pixel 3 XL) — extended support release for legacy devices with frozen 2021-11-01 patch level</li>
                         <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SP2A.220505.006.2022081600">SP2A.220505.006.2022081600</a> (Pixel 3a, Pixel 3a XL) — extended support release for legacy devices with frozen 2022-06-01 patch level</li>
-                        <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SD2A.220601.004.B2.2022081600">SD2A.220601.004.B2.2022081600</a> (Pixel 6a) — early release for Pixel 6a with 2022-06-01 patch level which is the latest available until there's a normal AOSP/stock OS release for it on the latest patch level</li>
+                        <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SD2A.220601.004.B2.2022081600">SD2A.220601.004.B2.2022081600</a> (Pixel 6a) — early release for Pixel 6a with 2022-06-01 patch level which is the latest available until there's a normal AOSP / stock OS release for it on the latest patch level</li>
                         <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SQ3A.220705.003.A1.2022081600">SQ3A.220705.003.A1.2022081600</a> (Pixel 4, Pixel 4 XL, Pixel 4a, Pixel 4a (5G), Pixel 5, Pixel 5a)</li>
                         <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SQ3A.220705.004.2022081600">SQ3A.220705.004.2022081600</a> (Pixel 6, Pixel 6 Pro, emulator, generic, other targets)</li>
                     </ul>
@@ -1759,7 +1759,7 @@
                         <li>Vanadium: backport using Android 13 SDK and changes to support using Android 13</li>
                         <li>Vanadium: update Chromium base to 104.0.5112.97</li>
                         <li>Vanadium: restore previous launcher icon</li>
-                        <li>Pixel 6a: switch to SD2A.220601.004.B2 (July 2022) device sources and vendor files (AOSP/stock OS patch level for Pixel 6a is still 2022-06-01 until Android 13)</li>
+                        <li>Pixel 6a: switch to SD2A.220601.004.B2 (July 2022) device sources and vendor files (AOSP / stock OS patch level for Pixel 6a is still 2022-06-01 until Android 13)</li>
                     </ul>
                 </article>
 
@@ -1770,7 +1770,7 @@
                     <ul>
                         <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SP1A.210812.016.C2.2022080900">SP1A.210812.016.C2.2022080900</a> (Pixel 3, Pixel 3 XL) — extended support release for legacy devices with frozen 2021-11-01 patch level</li>
                         <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SP2A.220505.006.2022080900">SP2A.220505.006.2022080900</a> (Pixel 3a, Pixel 3a XL) — extended support release for legacy devices with frozen 2022-06-01 patch level</li>
-                        <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SD2A.220601.004.2022080900">SD2A.220601.004.2022080900</a> (Pixel 6a) — early release for Pixel 6a with 2022-06-01 patch level which is the latest available until there's a normal AOSP/stock OS release for it on the latest patch level</li>
+                        <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SD2A.220601.004.2022080900">SD2A.220601.004.2022080900</a> (Pixel 6a) — early release for Pixel 6a with 2022-06-01 patch level which is the latest available until there's a normal AOSP / stock OS release for it on the latest patch level</li>
                         <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SQ3A.220705.003.A1.2022080900">SQ3A.220705.003.A1.2022080900</a> (Pixel 4, Pixel 4 XL, Pixel 4a, Pixel 4a (5G), Pixel 5, Pixel 5a)</li>
                         <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SQ3A.220705.004.2022080900">SQ3A.220705.004.2022080900</a> (Pixel 6, Pixel 6 Pro, emulator, generic, other targets)</li>
                     </ul>
@@ -1797,7 +1797,7 @@
                     <ul>
                         <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SP1A.210812.016.C2.2022080500">SP1A.210812.016.C2.2022080500</a> (Pixel 3, Pixel 3 XL) — extended support release for legacy devices with frozen 2021-11-01 patch level</li>
                         <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SP2A.220505.006.2022080500">SP2A.220505.006.2022080500</a> (Pixel 3a, Pixel 3a XL) — extended support release for legacy devices with frozen 2022-06-01 patch level</li>
-                        <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SD2A.220601.004.2022080500">SD2A.220601.004.2022080500</a> (Pixel 6a) — early release for Pixel 6a with 2022-06-01 patch level which is the latest available until there's a normal AOSP/stock OS release for it on the latest patch level</li>
+                        <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SD2A.220601.004.2022080500">SD2A.220601.004.2022080500</a> (Pixel 6a) — early release for Pixel 6a with 2022-06-01 patch level which is the latest available until there's a normal AOSP / stock OS release for it on the latest patch level</li>
                         <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SQ3A.220705.003.A1.2022080500">SQ3A.220705.003.A1.2022080500</a> (Pixel 4, Pixel 4 XL, Pixel 4a, Pixel 4a (5G), Pixel 5, Pixel 5a)</li>
                         <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SQ3A.220705.004.2022080500">SQ3A.220705.004.2022080500</a> (Pixel 6, Pixel 6 Pro, emulator, generic, other targets)</li>
                     </ul>
@@ -1819,7 +1819,7 @@
                     <ul>
                         <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SP1A.210812.016.C2.2022080300">SP1A.210812.016.C2.2022080300</a> (Pixel 3, Pixel 3 XL) — extended support release for legacy devices with frozen 2021-11-01 patch level</li>
                         <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SP2A.220505.006.2022080300">SP2A.220505.006.2022080300</a> (Pixel 3a, Pixel 3a XL) — extended support release for legacy devices with frozen 2022-06-01 patch level</li>
-                        <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SD2A.220601.004.2022080300">SD2A.220601.004.2022080300</a> (Pixel 6a) — early release for Pixel 6a with 2022-06-01 patch level which is the latest available until there's a normal AOSP/stock OS release for it on the latest patch level</li>
+                        <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SD2A.220601.004.2022080300">SD2A.220601.004.2022080300</a> (Pixel 6a) — early release for Pixel 6a with 2022-06-01 patch level which is the latest available until there's a normal AOSP / stock OS release for it on the latest patch level</li>
                         <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SQ3A.220705.003.A1.2022080300">SQ3A.220705.003.A1.2022080300</a> (Pixel 4, Pixel 4 XL, Pixel 4a, Pixel 4a (5G), Pixel 5, Pixel 5a, Pixel 6, Pixel 6 Pro, emulator, generic, other targets)</li>
                     </ul>
 
@@ -1843,7 +1843,7 @@
                     <ul>
                         <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SP1A.210812.016.C2.2022073000">SP1A.210812.016.C2.2022073000</a> (Pixel 3, Pixel 3 XL) — extended support release for legacy devices with frozen 2021-11-01 patch level</li>
                         <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SP2A.220505.006.2022073000">SP2A.220505.006.2022073000</a> (Pixel 3a, Pixel 3a XL) — extended support release for legacy devices with frozen 2022-06-01 patch level</li>
-                        <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SD2A.220601.004.2022073000">SD2A.220601.004.2022073000</a> (Pixel 6a) — early release for Pixel 6a with 2022-06-01 patch level which is the latest available until there's a normal AOSP/stock OS release for it on the latest patch level</li>
+                        <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SD2A.220601.004.2022073000">SD2A.220601.004.2022073000</a> (Pixel 6a) — early release for Pixel 6a with 2022-06-01 patch level which is the latest available until there's a normal AOSP / stock OS release for it on the latest patch level</li>
                         <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SQ3A.220705.003.A1.2022073000">SQ3A.220705.003.A1.2022073000</a> (Pixel 4, Pixel 4 XL, Pixel 4a, Pixel 4a (5G), Pixel 5, Pixel 5a, Pixel 6, Pixel 6 Pro, emulator, generic, other targets)</li>
                     </ul>
 
@@ -2544,7 +2544,7 @@
                         <li>Camera: update to <a href="https://github.com/GrapheneOS/Camera/releases/tag/17">version 17</a></li>
                         <li>Pixel 3, Pixel 3 XL, Pixel 3a, Pixel 3a XL, Pixel 4, Pixel 4 XL, Pixel 4a, Pixel 4a (5G), Pixel 5, Pixel 5a, Pixel 6, Pixel 6 Pro: remove unnecessary configuration/permissions for apps not included in AOSP/GrapheneOS</li>
                         <li>Pixel 3, Pixel 3 XL, Pixel 3a, Pixel 3a XL, Pixel 4, Pixel 4 XL, Pixel 4a, Pixel 4a (5G), Pixel 5, Pixel 5a, Pixel 6, Pixel 6 Pro: add RCS packages</li>
-                        <li>Pixel 3, Pixel 3 XL, Pixel 3a, Pixel 3a XL, Pixel 4, Pixel 4 XL, Pixel 4a, Pixel 4a (5G), Pixel 5, Pixel 5a, Pixel 6, Pixel 6 Pro: remove AOSP/stock OS configuration pinning the system camera and launcher in memory since it's wasteful</li>
+                        <li>Pixel 3, Pixel 3 XL, Pixel 3a, Pixel 3a XL, Pixel 4, Pixel 4 XL, Pixel 4a, Pixel 4a (5G), Pixel 5, Pixel 5a, Pixel 6, Pixel 6 Pro: remove AOSP / stock OS configuration pinning the system camera and launcher in memory since it's wasteful</li>
                         <li>Pixel 3, Pixel 3 XL, Pixel 3a, Pixel 3a XL, Pixel 4, Pixel 4 XL, Pixel 4a, Pixel 4a (5G), Pixel 5, Pixel 5a, Pixel 6, Pixel 6 Pro: stop forcing camera shutter sound on the Japanese hardware SKUs</li>
                     </ul>
                 </article>
@@ -2564,7 +2564,7 @@
                     <ul>
                         <li>Pixel 6, Pixel 6 Pro: full Pixel 2022-03-05 security patch level (Android 2022-03-05 security patch level was already provided early by GrapheneOS)</li>
                         <li>Pixel 6, Pixel 6 Pro: rebased onto SP2A.220305.013.A3 release</li>
-                        <li>kernel (Pixel 6, Pixel 6 Pro): update GKI base to android12-5.10-2021-12_r8 from the android12-5.10-2021-12_r6 version still used by the AOSP/stock Pixel OS March release for a few additional security fixes beyond the ones already backported early by GrapheneOS along with latency improvements under certain heavy real-time loads</li>
+                        <li>kernel (Pixel 6, Pixel 6 Pro): update GKI base to android12-5.10-2021-12_r8 from the android12-5.10-2021-12_r6 version still used by the AOSP / stock Pixel OS March release for a few additional security fixes beyond the ones already backported early by GrapheneOS along with latency improvements under certain heavy real-time loads</li>
                         <li>add eSIM activation support as an optional toggle available when using sandboxed Google Play in the Owner profile (note: regular apps including sandboxed Google Play do not have additional access in the Owner profile)</li>
                         <li>Sandboxed Google Play compatibility layer: expand PhenoTypeFlags workaround to all Play services clients</li>
                         <li>GmsCompat: call startForegroundService from the main thread to avoid potential issues</li>
@@ -2962,7 +2962,7 @@
                     <ul>
                         <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SP1A.210812.015.2022010500">SP1A.210812.015.2022010500</a> (Pixel 3, Pixel 3 XL) — extended support release for legacy devices with frozen 2021-11-01 patch level</li>
                         <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SQ1A.220105.002.2022010500">SQ1A.220105.002.2022010500</a> (Pixel 3a, Pixel 3a XL, Pixel 4, Pixel 4 XL, Pixel 4a, Pixel 4a (5G), Pixel 5, Pixel 5a, emulator, generic, other targets)</li>
-                        <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SQ1D.211205.017.2022010500">SQ1D.211205.017.2022010500</a> (Pixel 6, Pixel 6 Pro) — early release with the full Android 2022-01-05 patch level but only the 2022-01-01 Pixel patch level since the AOSP/stock OS January update for the Pixel 6 and Pixel 6 Pro is happening in late January so the patches specific to them aren't publicly available yet</li>
+                        <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SQ1D.211205.017.2022010500">SQ1D.211205.017.2022010500</a> (Pixel 6, Pixel 6 Pro) — early release with the full Android 2022-01-05 patch level but only the 2022-01-01 Pixel patch level since the AOSP / stock OS January update for the Pixel 6 and Pixel 6 Pro is happening in late January so the patches specific to them aren't publicly available yet</li>
                     </ul>
 
                     <p>Changes since the 2021122018 release:</p>
@@ -3895,7 +3895,7 @@
                         <li>integrate modern Android theme and wallpaper configuration</li>
                         <li>remove legacy WallpaperPicker app</li>
                         <li>System Updater: modernize update settings via androidx preference library (new theme has minor quirks we'll be fixing in the next release)</li>
-                        <li>use alternate grapheneos.online domain for connectivity check/captive portal fallback URLs to improve handling of future issues comparable to Quad9 temporarily blocking grapheneos.network due to some kind of false positive</li>
+                        <li>use alternate grapheneos.online domain for connectivity check / captive portal fallback URLs to improve handling of future issues comparable to Quad9 temporarily blocking grapheneos.network due to some kind of false positive</li>
                         <li>Pixel 3, Pixel 3 XL, Pixel 3a, Pixel 3a XL, Pixel 4, Pixel 4 XL, Pixel 4a, Pixel 4a (5G), Pixel 5: update APNs</li>
                         <li>Pixel 3, Pixel 3 XL, Pixel 3a, Pixel 3a XL, Pixel 4, Pixel 4 XL, Pixel 4a, Pixel 4a (5G), Pixel 5: update CarrierConfig vendor.xml</li>
                     </ul>
@@ -4519,7 +4519,7 @@
                     <p>Changes since the 2020.09.11.14 release:</p>
 
                     <ul>
-                        <li>initial port to Android 11 with most GrapheneOS changes ported over (missing most SELinux policy hardening, some Pixel 4/4 XL kernel side channel mitigations, finer-grained Pixel 4 kernel Control Flow Integrity and the setup wizard)</li>
+                        <li>initial port to Android 11 with most GrapheneOS changes ported over (missing most SELinux policy hardening, some Pixel 4 / 4 XL kernel side channel mitigations, finer-grained Pixel 4 kernel Control Flow Integrity and the setup wizard)</li>
                         <li>full 2020-09-05 security patch level</li>
                         <li>temporarily use stock WebView until the next release of Chromium is available with public support for Android 11 to provide the WebView via Vanadium again</li>
                         <li>fix VPN lockdown setting getting overridden on user stop</li>

--- a/static/source.html
+++ b/static/source.html
@@ -85,8 +85,8 @@
                 <p>The operating system has a unified build system, but some components like
                 Chromium are too complex to fit into it so they're included as prebuilts instead
                 of porting them to the AOSP build system. This is also done for developer
-                convenience and bootstrapping, to avoid needing to build all the native /
-                cross-compilation toolchains for each host and target platform combination, etc.
+                convenience and bootstrapping, to avoid needing to build all the native/cross-compilation 
+                toolchains for each host and target platform combination, etc.
                 The prebuilts can all be built from source if desired. The build instructions will
                 be expanded to cover all of this in the future.</p>
 

--- a/static/usage.html
+++ b/static/usage.html
@@ -638,7 +638,7 @@
                     images.</p>
 
                     <p>Our Camera app provides the system media intents used by other apps to
-                    capture images/record videos via the OS provided camera implementation.
+                    capture images or record videos via the OS provided camera implementation.
                     These intents can only be provided by a system app since Android 11, so the
                     quality of the system camera is quite important.</p>
 

--- a/static/usage.html
+++ b/static/usage.html
@@ -385,7 +385,7 @@
                 versions of the OS which will minimize bandwidth usage since incrementals will always
                 be available.</p>
 
-                <p>The updater works while the device is locked / idle, including before the first
+                <p>The updater works while the device is locked/idle, including before the first
                 unlock since it's explicitly designed to be able to run before decryption of user
                 data.</p>
 
@@ -422,7 +422,7 @@
 
                     <p>The "Notification settings" option is a shortcut to the System Updater notification
                     settings which allows you to control notification settings from System Updater such as
-                    notification dot, lock screen, and noisy / silent notifications. These notifications
+                    notification dot, lock screen, and noisy/silent notifications. These notifications
                     include updater errors, progress, already up to date, and reboot prompts. By default all
                     notifications are enabled.</p>
                 </section>
@@ -432,7 +432,7 @@
 
                     <p>The update server isn't a trusted party since updates are signed and verified along
                     with downgrade attacks being prevented. The update protocol doesn't send identifiable
-                    information to the update server and works well over a VPN / Tor. GrapheneOS isn't
+                    information to the update server and works well over a VPN/Tor. GrapheneOS isn't
                     able to comply with a government order to build, sign and ship a malicious update to a
                     specific user's device based on information like the IMEI, serial number, etc. The
                     update server only ends up knowing the IP address used to connect to it and the
@@ -590,7 +590,7 @@
                 a WebView implementation (GeckoView is not a WebView implementation), so it has to be
                 used alongside the Chromium-based WebView rather than instead of Chromium, which means
                 having the remote attack surface of two separate browser engines instead of only one.
-                Firefox / Gecko also bypass or cripple a fair bit of the upstream and GrapheneOS
+                Firefox/Gecko also bypass or cripple a fair bit of the upstream and GrapheneOS
                 hardening work for apps. Worst of all, Firefox does not have internal sandboxing
                 on Android. This is despite the fact that Chromium semantic sandbox layer on
                 Android is implemented via the OS <code>isolatedProcess</code> feature, which is a
@@ -619,7 +619,7 @@
                     <h3><a href="#grapheneos-camera-app">GrapheneOS Camera app</a></h3>
 
                     <p>GrapheneOS includes our own modern camera app focused on privacy and
-                    security. It includes modes for capturing images, videos and QR / barcode
+                    security. It includes modes for capturing images, videos and QR/barcode
                     scanning along with additional modes based on CameraX vendor extensions
                     (Portrait, HDR, Night, Face Retouch and Auto) on <a
                     href="https://developer.android.com/training/camerax/devices">devices where
@@ -638,7 +638,7 @@
                     images.</p>
 
                     <p>Our Camera app provides the system media intents used by other apps to
-                    capture images / record videos via the OS provided camera implementation.
+                    capture images/record videos via the OS provided camera implementation.
                     These intents can only be provided by a system app since Android 11, so the
                     quality of the system camera is quite important.</p>
 
@@ -681,7 +681,7 @@
                     setting determines the timeout before it switches back the default mode. The
                     exposure compensation slider on the left allows manually tuning exposure and
                     will automatically adjust shutter speed, aperture and ISO without disrupting
-                    lightweight HDR+ support. Further configuration / tuning will be provided in
+                    lightweight HDR+ support. Further configuration/tuning will be provided in
                     the future.</p>
 
                     <p>The QR scanning mode only scans within the scanning square marked on the
@@ -914,8 +914,8 @@
 
                 <p>This feature is not intended to improve the confidentiality of traditional calls and
                 texts, but it might somewhat raise the bar for some forms of interception. It's not a
-                substitute for end-to-end encrypted calls / texts or even transport layer encryption.
-                LTE does provide basic network authentication / encryption, but it's for the network
+                substitute for end-to-end encrypted calls/texts or even transport layer encryption.
+                LTE does provide basic network authentication/encryption, but it's for the network
                 itself. The intention of the LTE-only feature is only hardening against remote
                 exploitation by disabling an enormous amount of legacy code.</p>
             </section>
@@ -951,7 +951,7 @@
                 layer.</p>
 
                 <p>The vast majority of Play services functionality works perfectly including
-                dynamically downloaded / updated modules (dynamite modules) and functionality
+                dynamically downloaded/updated modules (dynamite modules) and functionality
                 provided by modular app components such as Google Play Games. By default, location
                 requests are rerouted to a reimplementation of the Play geolocation service
                 provided by GrapheneOS. You can disable rerouting and use the standard Play
@@ -960,7 +960,7 @@
 
                 <p>Our compatibility layer includes full support for the Play Store. Play Store
                 services are fully available including in-app purchases, Play Asset Delivery, Play
-                Feature Delivery and app / content license checks. It can install, update and
+                Feature Delivery and app/content license checks. It can install, update and
                 uninstall apps with the standard approach requiring that the user authorizes it as
                 an app source and consents to each action. It will use the standard Android 12+
                 unattended update feature to do automatic updates for apps where it was the last
@@ -1049,7 +1049,7 @@
 
                     <p>Re-routing location to the OS geolocation service will use more power than
                     using the Google Play geolocation service since we do not provide a
-                    network-based location service and implement it via GNSS / A-GPS only. In the
+                    network-based location service and implement it via GNSS/A-GPS only. In the
                     future, we plan on providing a pseudo-network geolocation service for the OS
                     by using a local database of cell towers, and the location redirection feature
                     can also make use of this future OS implementation for network location
@@ -1074,7 +1074,7 @@
                     we can teach it to use the regular approach available to a normal app. In some
                     cases, the functionality it offers fundamentally requires privileged
                     access and cannot be supported. For example, it's unlikely Android Auto will be
-                    supported. The same applies to other highly invasive OS integration / control
+                    supported. The same applies to other highly invasive OS integration/control
                     or privileged access to hardware. Our compatibility layer is a very actively
                     developed work in progress and most of the remaining unavailable functionality
                     is quickly becoming supported. In the future, we can also support redirection


### PR DESCRIPTION
Removed extra space in ` / ` string for uniformity across the site and better readability.