### PR TITLE
Revert "update platform-tools to r34.0.0"

### DIFF
--- a/static/install/cli.html
+++ b/static/install/cli.html
@@ -253,21 +253,21 @@
                     Ubuntu:</p>
 
                     <pre>sudo apt install libarchive-tools
-curl -O https://dl.google.com/android/repository/platform-tools_r34.0.0-linux.zip
-echo '8137c2834dea05cb64c1a8bc041ea00fcd43e3a8a29429ad4f25b8ee51efebf6  platform-tools_r34.0.0-linux.zip' | sha256sum -c
-bsdtar xvf platform-tools_r34.0.0-linux.zip</pre>
+curl -O https://dl.google.com/android/repository/platform-tools_r33.0.3-linux.zip
+echo 'ab885c20f1a9cb528eb145b9208f53540efa3d26258ac3ce4363570a0846f8f7  platform-tools_r33.0.3-linux.zip' | sha256sum -c
+bsdtar xvf platform-tools_r33.0.3-linux.zip</pre>
 
                     <p>To download, verify and extract the standalone platform-tools on macOS:</p>
 
-                    <pre>curl -O https://dl.google.com/android/repository/platform-tools_r34.0.0-darwin.zip
-echo 'SHA256 (platform-tools_r34.0.0-darwin.zip) = 15910dc3d38f29278fd177db61ab26126516a75d0086862dbd27c9c76b8888e6' | shasum -c
-tar xvf platform-tools_r34.0.0-darwin.zip</pre>
+                    <pre>curl -O https://dl.google.com/android/repository/platform-tools_r33.0.3-darwin.zip
+echo 'SHA256 (platform-tools_r33.0.3-darwin.zip) = 84acbbd2b2ccef159ae3e6f83137e44ad18388ff3cc66bb057c87d761744e595' | shasum -c
+tar xvf platform-tools_r33.0.3-darwin.zip</pre>
 
                     <p>To download, verify and extract the standalone platform-tools on Windows:</p>
 
-                    <pre>curl -O https://dl.google.com/android/repository/platform-tools_r34.0.0-windows.zip
-(Get-FileHash platform-tools_r34.0.0-windows.zip).hash -eq "ae647ea7243f32e1735b8c52201c48a426cd756b65eaa15f47063c3579191001"
-tar xvf platform-tools_r34.0.0-windows.zip</pre>
+                    <pre>curl -O https://dl.google.com/android/repository/platform-tools_r33.0.3-windows.zip
+(Get-FileHash platform-tools_r33.0.3-windows.zip).hash -eq "1e59afd40a74c5c0eab0a9fad3f0faf8a674267106e0b19921be9f67081808c2"
+tar xvf platform-tools_r33.0.3-windows.zip</pre>
 
                     <p>Next, add the tools to your <code>PATH</code> in the current shell so they can be
                     used without referencing them by file path, enabling usage by the flashing script.</p>
@@ -293,7 +293,7 @@ tar xvf platform-tools_r34.0.0-windows.zip</pre>
                 <p>Example of the output after following the instructions above for the
                 standalone platform-tools:</p>
 
-                <pre>fastboot version 34.0.0-9570255
+                <pre>fastboot version 33.0.3-8952118
 Installed as /home/username/platform-tools/fastboot</pre>
             </section>
 


### PR DESCRIPTION
This reverts commit 6a0e6def494795509378c12f646df26e05578f0b.

Because of broken "flash-all" logic ("fastboot update" command) in this release of platform-tools.

Bug: https://issuetracker.google.com/issues/268872725
Broken commit: https://android-review.googlesource.com/c/platform/system/core/+/2403584