### PR TITLE
Add grapheneos.social Mastodon Instance to Services Section

### DIFF
--- a/static/source.html
+++ b/static/source.html
@@ -260,6 +260,7 @@
                     <li><a href="https://github.com/GrapheneOS/matrix.grapheneos.org">matrix.grapheneos.org</a>: Matrix and Element Web server</li>
                     <li><a href="https://github.com/GrapheneOS/ns1.grapheneos.org">ns1.grapheneos.org</a>: DNS servers</li>
                     <li><a href="https://github.com/GrapheneOS/discuss.grapheneos.org">discuss.grapheneos.org</a>: Discussion forum server</li>
+                    <li><a href="https://github.com/GrapheneOS/grapheneos.social">grapheneos.social</a>: Mastodon instance</li>
                 </ul>
             </section>
 


### PR DESCRIPTION
GrapheneOS shares most of its source code for its services and adds links pointing to these repositories. Since GrapheneOS is sharing its Mastodon configuration code at https://github.com/GrapheneOS/grapheneos.social, add link to repository to Services section of Source webpage of main GrapheneOS website.