### PR TITLE
Remove autofill from Vanadium roadmap as it has already been implemented

### DIFF
--- a/static/usage.html
+++ b/static/usage.html
@@ -523,7 +523,7 @@
                 <p>Vanadium was previously primarily focused on security hardening but we plan on
                 adding assorted privacy and usability features. In the near future, we plan to add
                 support for always incognito mode, content filtering (ad blocking, etc.), improved
-                state partitioning, backup/restore,and many other features.</p>
+                state partitioning, backup/restore, and many other features.</p>
 
                 <p>Chromium-based browsers like Vanadium provide the strongest sandbox
                 implementation, leagues ahead of the alternatives. It is much harder to escape

--- a/static/usage.html
+++ b/static/usage.html
@@ -523,7 +523,7 @@
                 <p>Vanadium was previously primarily focused on security hardening but we plan on
                 adding assorted privacy and usability features. In the near future, we plan to add
                 support for always incognito mode, content filtering (ad blocking, etc.), improved
-                state partitioning, backup/restore, native autofill and many other features.</p>
+                state partitioning, backup/restore,and many other features.</p>
 
                 <p>Chromium-based browsers like Vanadium provide the strongest sandbox
                 implementation, leagues ahead of the alternatives. It is much harder to escape


### PR DESCRIPTION
This PR removes native autofill from to-do features for Vanadium, as it has already been implemented.