### PR TITLE
Add bleeding edge code mention to LTE-only section in Usage guide

### DIFF
--- a/static/usage.html
+++ b/static/usage.html
@@ -927,7 +927,8 @@
                 substitute for end-to-end encrypted calls / texts or even transport layer encryption.
                 LTE does provide basic network authentication / encryption, but it's for the network
                 itself. The intention of the LTE-only feature is only hardening against remote
-                exploitation by disabling an enormous amount of legacy code.</p>
+                exploitation by disabling an enormous amount of both legacy code (2G, 3G) and bleeding
+                edge code (5G).</p>
             </section>
 
             <section id="sandboxed-google-play">


### PR DESCRIPTION
This PR adds mention of bleeding edge code (5G) being disabled via the LTE-only mode feature, which matches the LTE-only mode entry in the Features page (https://grapheneos.org/features#lte-only-mode). 