### PR TITLE
reorder GrapheneOS services privacy policy + add few missing ones

### DIFF
--- a/static/faq.html
+++ b/static/faq.html
@@ -1101,15 +1101,17 @@
                         <li>grapheneos.network</li>
                         <li>grapheneos.online</li>
                         <li>grapheneos.org</li>
-                        <li>releases.grapheneos.org</li>
-                        <li>time.grapheneos.org</li>
-                        <li>supl.grapheneos.org</li>
+                        <li>grapheneos.social</li>
                         <li>apps.grapheneos.org</li>
+                        <li>broadcom.psds.grapheneos.org</li>
                         <li>discuss.grapheneos.org</li>
-                        <li>matrix.grapheneos.org</li>
                         <li>element.grapheneos.org</li>
                         <li>mail.grapheneos.org</li>
-                        <li>grapheneos.social</li>
+                        <li>matrix.grapheneos.org</li>
+                        <li>releases.grapheneos.org</li>
+                        <li>remoteprovisioning.grapheneos.org</li>
+                        <li>supl.grapheneos.org</li>
+                        <li>time.grapheneos.org</li>
                     </ul>
 
                     <p>Our implementation of the policy primarily consists of making sure our servers only


### PR DESCRIPTION
Broadcom PSDS, attestation key remote provisioning, DNS over TLS check

left out connectivitycheck.grapheneos.network as grapheneos.network seems dedicated to network stuff anyways