### PR TITLE
drop recommendation for host kernel version

### DIFF
--- a/static/build.html
+++ b/static/build.html
@@ -215,9 +215,7 @@
                     <h3><a href="#build-dependencies">Build dependencies</a></h3>
 
                     <p>Arch Linux, Debian bullseye, Ubuntu 22.10 and Ubuntu 22.04 LTS are the
-                    officially supported operating systems for building GrapheneOS. Linux 5.15 LTS
-                    (linux-lts package) is recommended on Arch Linux due to newer Linux kernel
-                    releases causing non-deterministic OpenJDK crashes during builds.</p>
+                    officially supported operating systems for building GrapheneOS.</p>
 
                     <p>Dependencies for fetching and verifying the sources:</p>
 


### PR DESCRIPTION
the bug which was introduced in Linux 6.1 got fixed in both linux and linux-lts