### PR TITLE
Document that updating disabled apps no longer enables them

### DIFF
--- a/static/features.html
+++ b/static/features.html
@@ -900,7 +900,8 @@
                     uninstall it and lose their app data. This is much stricter than the standard
                     force stop feature which only prevents an app from starting itself and the app
                     will start running again as soon as another app tries to open an activity or
-                    service it provides.</p>
+                    service it provides. It also makes it so updating a disabled app doesn't
+                    re-enable it, so that apps can be kept up-to-date until they're needed again.</p>
                 </section>
 
                 <section id="other-features">


### PR DESCRIPTION
This PR adds information to https://grapheneos.org/features#user-installed-apps-can-be-disabled regarding the fact that GrapheneOS adjusts the default AOSP behavior of re-enabling disabled apps when you update them.

It felt relevant as an addition to that section instead of adding it to the "Other features" section.

If there are issues with wording, or this needs to be in another section, feel free to close.