### PR TITLE
Document that updating disabled apps doesn't re-enable them

### DIFF
--- a/static/features.html
+++ b/static/features.html
@@ -961,6 +961,8 @@
                         storage with recordings stored in Recordings/Call Recordings and no restrictions based
                         on region or special cases like playing a recording tone (users are still responsible
                         for complying with their local laws).</li>
+                        <li>Change standard Android package installer behavior to preserving packages being 
+                        disabled after updating them instead of them being re-enabled.</li>
                     </ul>
                 </section>
             </section>


### PR DESCRIPTION
This PR replaces https://github.com/GrapheneOS/grapheneos.org/pull/643, and this feature is now under the "Other features" section.