### PR TITLE
2G docs

### DIFF
--- a/static/usage.html
+++ b/static/usage.html
@@ -1281,8 +1281,9 @@
                 and Cellcom US are using this standard.</p>
 
                 <p>GrapheneOS includes bypasses for carrier restrictions on APN editing, tethering via
-                USB, Ethernet, Bluetooth and Wi-Fi and the ability to disable 2G, actions which would not
-                necessarily have been possible on the stock operating system.</p>
+                USB, Ethernet, Bluetooth and Wi-Fi and the ability to disable 2G (only on 6th and 7th
+                generation Pixel devices), actions which would not necessarily have been possible on
+                the stock operating system.</p>
             </section>
         </main>
         <footer>

--- a/static/usage.html
+++ b/static/usage.html
@@ -1257,7 +1257,8 @@
                     <li>Follow your carrier's instructions for setting up APNs, this can be found in
                         Settings ➔ Network &amp; Internet ➔ SIMs ➔ Access Point Names</li>
                     <li>If calls do not work and you have <a href="#lte-only-mode">LTE-only mode</a> enabled,
-                        try toggling it off. Your carrier may not properly support VoLTE.</li>
+                        try toggling it off. If "Allow 2G" is disabled, try toggling it back on. Your carrier
+                        may not properly support VoLTE.</li>
                     <li>As a last resort you may need to ask your carrier for a replacement SIM card.</li>
                 </ul>
 


### PR DESCRIPTION
Some users find that they need to turn on allow 2G for calls to work, and clarify the 2G feature is a 6th and 7th gen feature