### PR TITLE
Explain how to add a search engine to Vanadium and set as default

### DIFF
--- a/static/usage.html
+++ b/static/usage.html
@@ -601,6 +601,22 @@
                 sites from each other rather than only containing content as a whole. The sandbox
                 has been gradually improving on the desktop but it isn't happening for their
                 Android browser yet.</p>
+                
+                <p>Vanadium supports custom search engines through the <a
+                href="https://developer.mozilla.org/en-US/docs/Web/OpenSearch">OpenSearch</a> format.
+                To add a custom search engine and set it as the default search engine, the process is 
+                as follows:</p>
+
+                <ol> 
+                    <li>Go to the website and perform a search.</li> 
+                    <li>Go to <strong>Settings > Search Engine</strong> and set the search engine 
+                    which now appears under <strong>Recently Visited</strong> as the default search 
+                    engine.</li> 
+                </ol>
+
+                <p>If the search engine does not appear even after performing a search, it likely 
+                does not serve an OpenSearch document, and cannot be added as a custom search 
+                engine.</p>
             </section>
 
             <section id="camera">

--- a/static/usage.html
+++ b/static/usage.html
@@ -602,10 +602,10 @@
                 has been gradually improving on the desktop but it isn't happening for their
                 Android browser yet.</p>
                 
-                <p>Vanadium supports custom search engines through the <a
+                <p>Vanadium supports adding search engines through the <a
                 href="https://developer.mozilla.org/en-US/docs/Web/OpenSearch">OpenSearch</a> format.
-                To add a custom search engine and set it as the default search engine, the process is 
-                as follows:</p>
+                To add a search engine and set it as the default search engine, the process is as
+                follows:</p>
 
                 <ol> 
                     <li>Go to the website and perform a search.</li> 
@@ -614,9 +614,14 @@
                     engine.</li> 
                 </ol>
 
-                <p>If the search engine does not appear even after performing a search, it likely 
-                does not serve an OpenSearch document, and cannot be added as a custom search 
-                engine.</p>
+                <p>If the search engine does not appear even after performing a search, it may be
+                using POST HTTP requests by default to handle your queries, even if the website serves
+                an OpenSearch Document. For Vanadium to detect the search engine, queries need to be
+                made with GET HTTP requests.</p>
+                
+                <p>If you have turned on GET HTTP requests with the search engine and Vanadium still
+                does not detect the search engine, it likely does not serve an OpenSearch document, and 
+                cannot be added as a search engine.</p>
             </section>
 
             <section id="camera">


### PR DESCRIPTION
It isn't obvious that Vanadium supports adding search engines, which leads users to open issues asking for this feature: https://github.com/GrapheneOS/Vanadium/issues/254

A short note explaining how to add a search engine and set it as the default search engine will help new users setup their new browser with their choice of privacy-respecting search engine.