### PR TITLE
Mention move of PSDS setting to Location Settings

### DIFF
--- a/static/releases.html
+++ b/static/releases.html
@@ -617,7 +617,7 @@
                     <p>Changes since the 2023050100 release:</p>
 
                     <ul>
-                        <li>add support for disabling PSDS in addition to the GrapheneOS server and standard server options (the setting was also moved to Settings ➔ Location just like our SUPL setting)</li>
+                        <li>add support for disabling PSDS in addition to the GrapheneOS server and standard server options (the setting was also moved to Settings ➔ Location, just like our SUPL setting)</li>
                         <li>Pixel 4, Pixel 4 XL, Pixel 4a, Pixel 4a (5G), Pixel 5, Pixel 5a: add support for controlling PSDS on Qualcomm SoC devices to extend PSDS configuration to them along with using the GrapheneOS PSDS cache by default</li>
                         <li>Pixel 4, Pixel 4 XL, Pixel 4a, Pixel 4a (5G), Pixel 5, Pixel 5a: disable User-Agent for Qualcomm PSDS (XTRA) via xtra-daemon hooking to avoid providing device information to the server (we already removed the hardware identifier via SELinux policy in a previous release)</li>
                         <li>Pixel 4, Pixel 4 XL, Pixel 4a, Pixel 4a (5G), Pixel 5, Pixel 5a: use time.grapheneos.org for XTRA NTP and qualcomm.psds.grapheneos.org for XTRA PSDS downloads by default</li>

--- a/static/releases.html
+++ b/static/releases.html
@@ -617,7 +617,7 @@
                     <p>Changes since the 2023050100 release:</p>
 
                     <ul>
-                        <li>add support for disabling PSDS in addition to the GrapheneOS server and standard server options</li>
+                        <li>add support for disabling PSDS in addition to the GrapheneOS server and standard server options (the setting was also moved to Settings ➔ Location just like our SUPL setting)</li>
                         <li>Pixel 4, Pixel 4 XL, Pixel 4a, Pixel 4a (5G), Pixel 5, Pixel 5a: add support for controlling PSDS on Qualcomm SoC devices to extend PSDS configuration to them along with using the GrapheneOS PSDS cache by default</li>
                         <li>Pixel 4, Pixel 4 XL, Pixel 4a, Pixel 4a (5G), Pixel 5, Pixel 5a: disable User-Agent for Qualcomm PSDS (XTRA) via xtra-daemon hooking to avoid providing device information to the server (we already removed the hardware identifier via SELinux policy in a previous release)</li>
                         <li>Pixel 4, Pixel 4 XL, Pixel 4a, Pixel 4a (5G), Pixel 5, Pixel 5a: use time.grapheneos.org for XTRA NTP and qualcomm.psds.grapheneos.org for XTRA PSDS downloads by default</li>


### PR DESCRIPTION
This explains that the PSDS setting was moved from Settings ➔ Network & Internet to Settings ➔ Location.

Some people are confused about it, so it would be good to mention that:

https://discuss.grapheneos.org/d/4870-grapheneos-version-2023050500-released/8