### PR TITLE
Fix CameraX extension device availability link

### DIFF
--- a/static/usage.html
+++ b/static/usage.html
@@ -624,8 +624,8 @@
                     security. It includes modes for capturing images, videos and QR / barcode
                     scanning along with additional modes based on CameraX vendor extensions
                     (Portrait, HDR, Night, Face Retouch and Auto) on <a
-                    href="https://developer.android.com/training/camerax/devices">devices where
-                    they're available</a> (not available on Pixels yet).</p>
+                    href="https://developer.android.com/training/camera/supported-devices">devices
+                    where they're available</a> (not available on Pixels yet).</p>
 
                     <p>Modes are displayed as tabs at the bottom of the screen. You can switch
                     between modes using the tab interface or by swiping left/right anywhere on the


### PR DESCRIPTION
The link was incorrectly pointing to CameraX availability instead of Camera extension.