### PR TITLE
Fix link to supported CameraX extension devices

### DIFF
--- a/static/usage.html
+++ b/static/usage.html
@@ -624,7 +624,7 @@
                     security. It includes modes for capturing images, videos and QR / barcode
                     scanning along with additional modes based on CameraX vendor extensions
                     (Portrait, HDR, Night, Face Retouch and Auto) on <a
-                    href="https://developer.android.com/training/camerax/devices">devices where
+                    href="https://developer.android.com/training/camera/supported-devices">devices where
                     they're available</a> (not available on Pixels yet).</p>
 
                     <p>Modes are displayed as tabs at the bottom of the screen. You can switch


### PR DESCRIPTION
This PR replaces the current link which lists devices with CameraX support, to the link which lists devices with CameraX vendor extension support, which is what that section seems to be talking about.