### PR TITLE
Add Mastodon link to footer

### DIFF
--- a/static/404.html
+++ b/static/404.html
@@ -57,6 +57,7 @@
             <ul id="social">
                 <li><a href="https://discuss.grapheneos.org/">Forum</a></li>
                 <li><a href="https://twitter.com/GrapheneOS">Twitter</a></li>
+                <li><a href="https://grapheneos.social/@GrapheneOS">Mastodon</a></li>
                 <li><a href="https://github.com/GrapheneOS">GitHub</a></li>
                 <li><a href="https://reddit.com/r/GrapheneOS">Reddit</a></li>
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>

--- a/static/articles/attestation-compatibility-guide.html
+++ b/static/articles/attestation-compatibility-guide.html
@@ -132,6 +132,7 @@
             <ul id="social">
                 <li><a href="https://discuss.grapheneos.org/">Forum</a></li>
                 <li><a href="https://twitter.com/GrapheneOS">Twitter</a></li>
+                <li><a href="https://grapheneos.social/@GrapheneOS">Mastodon</a></li>
                 <li><a href="https://github.com/GrapheneOS">GitHub</a></li>
                 <li><a href="https://reddit.com/r/GrapheneOS">Reddit</a></li>
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>

--- a/static/articles/grapheneos-servers.html
+++ b/static/articles/grapheneos-servers.html
@@ -658,6 +658,7 @@
             <ul id="social">
                 <li><a href="https://discuss.grapheneos.org/">Forum</a></li>
                 <li><a href="https://twitter.com/GrapheneOS">Twitter</a></li>
+                <li><a href="https://grapheneos.social/@GrapheneOS">Mastodon</a></li>
                 <li><a href="https://github.com/GrapheneOS">GitHub</a></li>
                 <li><a href="https://reddit.com/r/GrapheneOS">Reddit</a></li>
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>

--- a/static/articles/index.html
+++ b/static/articles/index.html
@@ -81,6 +81,7 @@
             <ul id="social">
                 <li><a href="https://discuss.grapheneos.org/">Forum</a></li>
                 <li><a href="https://twitter.com/GrapheneOS">Twitter</a></li>
+                <li><a href="https://grapheneos.social/@GrapheneOS">Mastodon</a></li>
                 <li><a href="https://github.com/GrapheneOS">GitHub</a></li>
                 <li><a href="https://reddit.com/r/GrapheneOS">Reddit</a></li>
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>

--- a/static/articles/server-traffic-shaping.html
+++ b/static/articles/server-traffic-shaping.html
@@ -262,6 +262,7 @@ PriorityQueueingPreset=besteffort</pre>
             <ul id="social">
                 <li><a href="https://discuss.grapheneos.org/">Forum</a></li>
                 <li><a href="https://twitter.com/GrapheneOS">Twitter</a></li>
+                <li><a href="https://grapheneos.social/@GrapheneOS">Mastodon</a></li>
                 <li><a href="https://github.com/GrapheneOS">GitHub</a></li>
                 <li><a href="https://reddit.com/r/GrapheneOS">Reddit</a></li>
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>

--- a/static/articles/sitewide-advertising-industry-opt-out.html
+++ b/static/articles/sitewide-advertising-industry-opt-out.html
@@ -82,6 +82,7 @@
             <ul id="social">
                 <li><a href="https://discuss.grapheneos.org/">Forum</a></li>
                 <li><a href="https://twitter.com/GrapheneOS">Twitter</a></li>
+                <li><a href="https://grapheneos.social/@GrapheneOS">Mastodon</a></li>
                 <li><a href="https://github.com/GrapheneOS">GitHub</a></li>
                 <li><a href="https://reddit.com/r/GrapheneOS">Reddit</a></li>
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>

--- a/static/build.html
+++ b/static/build.html
@@ -1463,6 +1463,7 @@ rm android-cts-media-1.5.zip</pre>
             <ul id="social">
                 <li><a href="https://discuss.grapheneos.org/">Forum</a></li>
                 <li><a href="https://twitter.com/GrapheneOS">Twitter</a></li>
+                <li><a href="https://grapheneos.social/@GrapheneOS">Mastodon</a></li>
                 <li><a href="https://github.com/GrapheneOS">GitHub</a></li>
                 <li><a href="https://reddit.com/r/GrapheneOS">Reddit</a></li>
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>

--- a/static/camera-privacy-policy.html
+++ b/static/camera-privacy-policy.html
@@ -83,6 +83,7 @@
             <ul id="social">
                 <li><a href="https://discuss.grapheneos.org/">Forum</a></li>
                 <li><a href="https://twitter.com/GrapheneOS">Twitter</a></li>
+                <li><a href="https://grapheneos.social/@GrapheneOS">Mastodon</a></li>
                 <li><a href="https://github.com/GrapheneOS">GitHub</a></li>
                 <li><a href="https://reddit.com/r/GrapheneOS">Reddit</a></li>
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>

--- a/static/contact.html
+++ b/static/contact.html
@@ -220,6 +220,7 @@
             <ul id="social">
                 <li><a href="https://discuss.grapheneos.org/">Forum</a></li>
                 <li><a href="https://twitter.com/GrapheneOS">Twitter</a></li>
+                <li><a href="https://grapheneos.social/@GrapheneOS">Mastodon</a></li>
                 <li><a href="https://github.com/GrapheneOS">GitHub</a></li>
                 <li><a href="https://reddit.com/r/GrapheneOS">Reddit</a></li>
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>

--- a/static/donate.html
+++ b/static/donate.html
@@ -209,6 +209,7 @@
             <ul id="social">
                 <li><a href="https://discuss.grapheneos.org/">Forum</a></li>
                 <li><a href="https://twitter.com/GrapheneOS">Twitter</a></li>
+                <li><a href="https://grapheneos.social/@GrapheneOS">Mastodon</a></li>
                 <li><a href="https://github.com/GrapheneOS">GitHub</a></li>
                 <li><a href="https://reddit.com/r/GrapheneOS">Reddit</a></li>
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>

--- a/static/faq.html
+++ b/static/faq.html
@@ -1850,6 +1850,7 @@
             <ul id="social">
                 <li><a href="https://discuss.grapheneos.org/">Forum</a></li>
                 <li><a href="https://twitter.com/GrapheneOS">Twitter</a></li>
+                <li><a href="https://grapheneos.social/@GrapheneOS">Mastodon</a></li>
                 <li><a href="https://github.com/GrapheneOS">GitHub</a></li>
                 <li><a href="https://reddit.com/r/GrapheneOS">Reddit</a></li>
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>

--- a/static/features.html
+++ b/static/features.html
@@ -1056,6 +1056,7 @@
             <ul id="social">
                 <li><a href="https://discuss.grapheneos.org/">Forum</a></li>
                 <li><a href="https://twitter.com/GrapheneOS">Twitter</a></li>
+                <li><a href="https://grapheneos.social/@GrapheneOS">Mastodon</a></li>
                 <li><a href="https://github.com/GrapheneOS">GitHub</a></li>
                 <li><a href="https://reddit.com/r/GrapheneOS">Reddit</a></li>
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>

--- a/static/history/copperheados.html
+++ b/static/history/copperheados.html
@@ -129,6 +129,7 @@
             <ul id="social">
                 <li><a href="https://discuss.grapheneos.org/">Forum</a></li>
                 <li><a href="https://twitter.com/GrapheneOS">Twitter</a></li>
+                <li><a href="https://grapheneos.social/@GrapheneOS">Mastodon</a></li>
                 <li><a href="https://github.com/GrapheneOS">GitHub</a></li>
                 <li><a href="https://reddit.com/r/GrapheneOS">Reddit</a></li>
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>

--- a/static/history/index.html
+++ b/static/history/index.html
@@ -114,6 +114,7 @@
             <ul id="social">
                 <li><a href="https://discuss.grapheneos.org/">Forum</a></li>
                 <li><a href="https://twitter.com/GrapheneOS">Twitter</a></li>
+                <li><a href="https://grapheneos.social/@GrapheneOS">Mastodon</a></li>
                 <li><a href="https://github.com/GrapheneOS">GitHub</a></li>
                 <li><a href="https://reddit.com/r/GrapheneOS">Reddit</a></li>
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>

--- a/static/history/legacy-changelog.html
+++ b/static/history/legacy-changelog.html
@@ -2190,6 +2190,7 @@
             <ul id="social">
                 <li><a href="https://discuss.grapheneos.org/">Forum</a></li>
                 <li><a href="https://twitter.com/GrapheneOS">Twitter</a></li>
+                <li><a href="https://grapheneos.social/@GrapheneOS">Mastodon</a></li>
                 <li><a href="https://github.com/GrapheneOS">GitHub</a></li>
                 <li><a href="https://reddit.com/r/GrapheneOS">Reddit</a></li>
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>

--- a/static/index.html
+++ b/static/index.html
@@ -141,6 +141,7 @@
             <ul id="social">
                 <li><a href="https://discuss.grapheneos.org/">Forum</a></li>
                 <li><a href="https://twitter.com/GrapheneOS">Twitter</a></li>
+                <li><a href="https://grapheneos.social/@GrapheneOS">Mastodon</a></li>
                 <li><a href="https://github.com/GrapheneOS">GitHub</a></li>
                 <li><a href="https://reddit.com/r/GrapheneOS">Reddit</a></li>
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>

--- a/static/install/cli.html
+++ b/static/install/cli.html
@@ -653,6 +653,7 @@ curl -O https://releases.grapheneos.org/<var>DEVICE_NAME</var>-factory-202111012
             <ul id="social">
                 <li><a href="https://discuss.grapheneos.org/">Forum</a></li>
                 <li><a href="https://twitter.com/GrapheneOS">Twitter</a></li>
+                <li><a href="https://grapheneos.social/@GrapheneOS">Mastodon</a></li>
                 <li><a href="https://github.com/GrapheneOS">GitHub</a></li>
                 <li><a href="https://reddit.com/r/GrapheneOS">Reddit</a></li>
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>

--- a/static/install/index.html
+++ b/static/install/index.html
@@ -78,6 +78,7 @@
             <ul id="social">
                 <li><a href="https://discuss.grapheneos.org/">Forum</a></li>
                 <li><a href="https://twitter.com/GrapheneOS">Twitter</a></li>
+                <li><a href="https://grapheneos.social/@GrapheneOS">Mastodon</a></li>
                 <li><a href="https://github.com/GrapheneOS">GitHub</a></li>
                 <li><a href="https://reddit.com/r/GrapheneOS">Reddit</a></li>
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>

--- a/static/install/web.html
+++ b/static/install/web.html
@@ -468,6 +468,7 @@
             <ul id="social">
                 <li><a href="https://discuss.grapheneos.org/">Forum</a></li>
                 <li><a href="https://twitter.com/GrapheneOS">Twitter</a></li>
+                <li><a href="https://grapheneos.social/@GrapheneOS">Mastodon</a></li>
                 <li><a href="https://github.com/GrapheneOS">GitHub</a></li>
                 <li><a href="https://reddit.com/r/GrapheneOS">Reddit</a></li>
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>

--- a/static/pdfviewer-privacy-policy.html
+++ b/static/pdfviewer-privacy-policy.html
@@ -59,6 +59,7 @@
             <ul id="social">
                 <li><a href="https://discuss.grapheneos.org/">Forum</a></li>
                 <li><a href="https://twitter.com/GrapheneOS">Twitter</a></li>
+                <li><a href="https://grapheneos.social/@GrapheneOS">Mastodon</a></li>
                 <li><a href="https://github.com/GrapheneOS">GitHub</a></li>
                 <li><a href="https://reddit.com/r/GrapheneOS">Reddit</a></li>
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>

--- a/static/releases.html
+++ b/static/releases.html
@@ -6290,6 +6290,7 @@
             <ul id="social">
                 <li><a href="https://discuss.grapheneos.org/">Forum</a></li>
                 <li><a href="https://twitter.com/GrapheneOS">Twitter</a></li>
+                <li><a href="https://grapheneos.social/@GrapheneOS">Mastodon</a></li>
                 <li><a href="https://github.com/GrapheneOS">GitHub</a></li>
                 <li><a href="https://reddit.com/r/GrapheneOS">Reddit</a></li>
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>

--- a/static/source.html
+++ b/static/source.html
@@ -301,6 +301,7 @@
             <ul id="social">
                 <li><a href="https://discuss.grapheneos.org/">Forum</a></li>
                 <li><a href="https://twitter.com/GrapheneOS">Twitter</a></li>
+                <li><a href="https://grapheneos.social/@GrapheneOS">Mastodon</a></li>
                 <li><a href="https://github.com/GrapheneOS">GitHub</a></li>
                 <li><a href="https://reddit.com/r/GrapheneOS">Reddit</a></li>
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>

--- a/static/usage.html
+++ b/static/usage.html
@@ -1294,6 +1294,7 @@
             <ul id="social">
                 <li><a href="https://discuss.grapheneos.org/">Forum</a></li>
                 <li><a href="https://twitter.com/GrapheneOS">Twitter</a></li>
+                <li><a href="https://grapheneos.social/@GrapheneOS">Mastodon</a></li>
                 <li><a href="https://github.com/GrapheneOS">GitHub</a></li>
                 <li><a href="https://reddit.com/r/GrapheneOS">Reddit</a></li>
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>


### PR DESCRIPTION
This adds a link to the official GrapheneOS Mastodon account to the footer on all pages (where applicable).

Before:
<img src="https://github.com/GrapheneOS/grapheneos.org/assets/123981212/4bfab769-8e2d-4e3f-b4e7-1f26f69e2b24" width="50%"/>

After:
<img src="https://github.com/GrapheneOS/grapheneos.org/assets/123981212/1e112edb-7e49-4e4b-9d5c-ef21d102fb5f" width="50%"/>
