### PR TITLE
CSS: Enable smooth scrolling

### DIFF
--- a/static/main.css
+++ b/static/main.css
@@ -3,6 +3,7 @@
 
 html {
     height: -webkit-fill-available; /* replace with stretch when standardized */
+    scroll-behavior: smooth;
 }
 
 body {


### PR DESCRIPTION
This enables smooth scrolling thru CSS. This should make navigating the site a little more smooth.

| Before  | After |
| :-------------: | :-------------: |
| <img src="https://github.com/GrapheneOS/grapheneos.org/assets/123981212/92e2923d-ba21-4fe4-a0ca-43ab0e950cda" width="50%"/>  | <img src="https://github.com/GrapheneOS/grapheneos.org/assets/123981212/9fd441c1-3d08-4409-b603-fc9762d1cd93" width="50%"/>
