### PR TITLE
Fix overflow in footer on mobile devices

### DIFF
--- a/static/main.css
+++ b/static/main.css
@@ -218,7 +218,7 @@ footer {
     margin-left: auto;
     margin-right: auto;
     padding: 1em;
-    max-width: 800px;
+    max-width: 100vw;
     overflow-wrap: break-word;
     text-align: center;
 }
@@ -234,7 +234,7 @@ footer a, footer a:visited {
 }
 
 #social li {
-    display: inline;
+    display: inline-block;
     padding: 0 0.5em;
 }
 


### PR DESCRIPTION
After the changes I made in #684 went public, I realized that the footer didn't adjust properly on mobile devices, leading to undesired overflow of the social links list:

<img src="https://github.com/GrapheneOS/grapheneos.org/assets/123981212/2b2fe729-c012-4277-958e-603cd831cd8c" width="50%">

---

This PR fixes this issue by setting the max-width of the footer to the width of the screen. When doing so, I noticed that the overflow-wrap behavior for the social links list caused the text to break mid-word. This obviously doesn't look great, so I fixed this by changing the display property of the social list items to inline-block.

**The result:**

<img src="https://github.com/GrapheneOS/grapheneos.org/assets/123981212/cfd304c5-be10-45ac-a9a6-22d8bc964a0c" width="50%">