### PR TITLE
Add a scroll-to-top button

### DIFF
--- a/static/articles/attestation-compatibility-guide.html
+++ b/static/articles/attestation-compatibility-guide.html
@@ -28,6 +28,7 @@
         <link rel="manifest" href="/manifest.webmanifest"/>
         <link rel="license" href="/LICENSE.txt"/>
         <link rel="me" href="https://grapheneos.social/@GrapheneOS"/>
+        {{js|/js/scroll-button.js}}
     </head>
     <body>
         <header>
@@ -138,5 +139,6 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
+        <button id="scrollButton" class="scrollButton" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
     </body>
 </html>

--- a/static/articles/attestation-compatibility-guide.html
+++ b/static/articles/attestation-compatibility-guide.html
@@ -138,7 +138,7 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"/></button>
+        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg" alt="Scroll to top icon"/></button>
         {{js|/js/scroll-button.js}}
     </body>
 </html>

--- a/static/articles/attestation-compatibility-guide.html
+++ b/static/articles/attestation-compatibility-guide.html
@@ -138,7 +138,7 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"></button>
+        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"/></button>
         {{js|/js/scroll-button.js}}
     </body>
 </html>

--- a/static/articles/attestation-compatibility-guide.html
+++ b/static/articles/attestation-compatibility-guide.html
@@ -139,6 +139,6 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scrollButton" class="scrollButton" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
+        <button id="scroll-button" class="scroll-button" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
     </body>
 </html>

--- a/static/articles/attestation-compatibility-guide.html
+++ b/static/articles/attestation-compatibility-guide.html
@@ -28,7 +28,6 @@
         <link rel="manifest" href="/manifest.webmanifest"/>
         <link rel="license" href="/LICENSE.txt"/>
         <link rel="me" href="https://grapheneos.social/@GrapheneOS"/>
-        {{js|/js/scroll-button.js}}
     </head>
     <body>
         <header>
@@ -139,6 +138,7 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scroll-button" class="scroll-button" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
+        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"></button>
+        {{js|/js/scroll-button.js}}
     </body>
 </html>

--- a/static/articles/grapheneos-servers.html
+++ b/static/articles/grapheneos-servers.html
@@ -29,7 +29,6 @@
         <link rel="license" href="/LICENSE.txt"/>
         <link rel="me" href="https://grapheneos.social/@GrapheneOS"/>
         {{js|/js/redirect.js}}
-        {{js|/js/scroll-button.js}}
     </head>
     <body>
         <header>
@@ -665,6 +664,7 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scroll-button" class="scroll-button" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
+        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"></button>
+        {{js|/js/scroll-button.js}}
     </body>
 </html>

--- a/static/articles/grapheneos-servers.html
+++ b/static/articles/grapheneos-servers.html
@@ -29,6 +29,7 @@
         <link rel="license" href="/LICENSE.txt"/>
         <link rel="me" href="https://grapheneos.social/@GrapheneOS"/>
         {{js|/js/redirect.js}}
+        {{js|/js/scroll-button.js}}
     </head>
     <body>
         <header>
@@ -664,5 +665,6 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
+        <button id="scrollButton" class="scrollButton" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
     </body>
 </html>

--- a/static/articles/grapheneos-servers.html
+++ b/static/articles/grapheneos-servers.html
@@ -664,7 +664,7 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"/></button>
+        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg" alt="Scroll to top icon"/></button>
         {{js|/js/scroll-button.js}}
     </body>
 </html>

--- a/static/articles/grapheneos-servers.html
+++ b/static/articles/grapheneos-servers.html
@@ -664,7 +664,7 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"></button>
+        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"/></button>
         {{js|/js/scroll-button.js}}
     </body>
 </html>

--- a/static/articles/grapheneos-servers.html
+++ b/static/articles/grapheneos-servers.html
@@ -665,6 +665,6 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scrollButton" class="scrollButton" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
+        <button id="scroll-button" class="scroll-button" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
     </body>
 </html>

--- a/static/articles/index.html
+++ b/static/articles/index.html
@@ -87,7 +87,7 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"/></button>
+        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg" alt="Scroll to top icon"/></button>
         {{js|/js/scroll-button.js}}
     </body>
 </html>

--- a/static/articles/index.html
+++ b/static/articles/index.html
@@ -28,7 +28,6 @@
         <link rel="manifest" href="/manifest.webmanifest"/>
         <link rel="license" href="/LICENSE.txt"/>
         <link rel="me" href="https://grapheneos.social/@GrapheneOS"/>
-        {{js|/js/scroll-button.js}}
     </head>
     <body>
         <header>
@@ -88,6 +87,7 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scroll-button" class="scroll-button" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
+        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"></button>
+        {{js|/js/scroll-button.js}}
     </body>
 </html>

--- a/static/articles/index.html
+++ b/static/articles/index.html
@@ -87,7 +87,7 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"></button>
+        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"/></button>
         {{js|/js/scroll-button.js}}
     </body>
 </html>

--- a/static/articles/index.html
+++ b/static/articles/index.html
@@ -28,6 +28,7 @@
         <link rel="manifest" href="/manifest.webmanifest"/>
         <link rel="license" href="/LICENSE.txt"/>
         <link rel="me" href="https://grapheneos.social/@GrapheneOS"/>
+        {{js|/js/scroll-button.js}}
     </head>
     <body>
         <header>
@@ -87,5 +88,6 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
+        <button id="scrollButton" class="scrollButton" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
     </body>
 </html>

--- a/static/articles/index.html
+++ b/static/articles/index.html
@@ -88,6 +88,6 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scrollButton" class="scrollButton" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
+        <button id="scroll-button" class="scroll-button" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
     </body>
 </html>

--- a/static/articles/server-traffic-shaping.html
+++ b/static/articles/server-traffic-shaping.html
@@ -268,7 +268,7 @@ PriorityQueueingPreset=besteffort</pre>
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"/></button>
+        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg" alt="Scroll to top icon"/></button>
         {{js|/js/scroll-button.js}}
     </body>
 </html>

--- a/static/articles/server-traffic-shaping.html
+++ b/static/articles/server-traffic-shaping.html
@@ -268,7 +268,7 @@ PriorityQueueingPreset=besteffort</pre>
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"></button>
+        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"/></button>
         {{js|/js/scroll-button.js}}
     </body>
 </html>

--- a/static/articles/server-traffic-shaping.html
+++ b/static/articles/server-traffic-shaping.html
@@ -269,6 +269,6 @@ PriorityQueueingPreset=besteffort</pre>
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scrollButton" class="scrollButton" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
+        <button id="scroll-button" class="scroll-button" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
     </body>
 </html>

--- a/static/articles/server-traffic-shaping.html
+++ b/static/articles/server-traffic-shaping.html
@@ -28,6 +28,7 @@
         <link rel="manifest" href="/manifest.webmanifest"/>
         <link rel="license" href="/LICENSE.txt"/>
         <link rel="me" href="https://grapheneos.social/@GrapheneOS"/>
+        {{js|/js/scroll-button.js}}
     </head>
     <body>
         <header>
@@ -268,5 +269,6 @@ PriorityQueueingPreset=besteffort</pre>
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
+        <button id="scrollButton" class="scrollButton" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
     </body>
 </html>

--- a/static/articles/server-traffic-shaping.html
+++ b/static/articles/server-traffic-shaping.html
@@ -28,7 +28,6 @@
         <link rel="manifest" href="/manifest.webmanifest"/>
         <link rel="license" href="/LICENSE.txt"/>
         <link rel="me" href="https://grapheneos.social/@GrapheneOS"/>
-        {{js|/js/scroll-button.js}}
     </head>
     <body>
         <header>
@@ -269,6 +268,7 @@ PriorityQueueingPreset=besteffort</pre>
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scroll-button" class="scroll-button" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
+        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"></button>
+        {{js|/js/scroll-button.js}}
     </body>
 </html>

--- a/static/articles/sitewide-advertising-industry-opt-out.html
+++ b/static/articles/sitewide-advertising-industry-opt-out.html
@@ -89,6 +89,6 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scrollButton" class="scrollButton" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
+        <button id="scroll-button" class="scroll-button" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
     </body>
 </html>

--- a/static/articles/sitewide-advertising-industry-opt-out.html
+++ b/static/articles/sitewide-advertising-industry-opt-out.html
@@ -88,7 +88,7 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"></button>
+        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"/></button>
         {{js|/js/scroll-button.js}}
     </body>
 </html>

--- a/static/articles/sitewide-advertising-industry-opt-out.html
+++ b/static/articles/sitewide-advertising-industry-opt-out.html
@@ -88,7 +88,7 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"/></button>
+        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg" alt="Scroll to top icon"/></button>
         {{js|/js/scroll-button.js}}
     </body>
 </html>

--- a/static/articles/sitewide-advertising-industry-opt-out.html
+++ b/static/articles/sitewide-advertising-industry-opt-out.html
@@ -28,7 +28,6 @@
         <link rel="manifest" href="/manifest.webmanifest"/>
         <link rel="license" href="/LICENSE.txt"/>
         <link rel="me" href="https://grapheneos.social/@GrapheneOS"/>
-        {{js|/js/scroll-button.js}}
     </head>
     <body>
         <header>
@@ -89,6 +88,7 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scroll-button" class="scroll-button" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
+        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"></button>
+        {{js|/js/scroll-button.js}}
     </body>
 </html>

--- a/static/articles/sitewide-advertising-industry-opt-out.html
+++ b/static/articles/sitewide-advertising-industry-opt-out.html
@@ -28,6 +28,7 @@
         <link rel="manifest" href="/manifest.webmanifest"/>
         <link rel="license" href="/LICENSE.txt"/>
         <link rel="me" href="https://grapheneos.social/@GrapheneOS"/>
+        {{js|/js/scroll-button.js}}
     </head>
     <body>
         <header>
@@ -88,5 +89,6 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
+        <button id="scrollButton" class="scrollButton" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
     </body>
 </html>

--- a/static/build.html
+++ b/static/build.html
@@ -1469,7 +1469,7 @@ rm android-cts-media-1.5.zip</pre>
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"></button>
+        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"/></button>
         {{js|/js/scroll-button.js}}
     </body>
 </html>

--- a/static/build.html
+++ b/static/build.html
@@ -1470,6 +1470,6 @@ rm android-cts-media-1.5.zip</pre>
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scrollButton" class="scrollButton" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
+        <button id="scroll-button" class="scroll-button" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
     </body>
 </html>

--- a/static/build.html
+++ b/static/build.html
@@ -28,7 +28,6 @@
         <link rel="manifest" href="/manifest.webmanifest"/>
         <link rel="license" href="/LICENSE.txt"/>
         <link rel="me" href="https://grapheneos.social/@GrapheneOS"/>
-        {{js|/js/scroll-button.js}}
     </head>
     <body>
         <header>
@@ -1470,6 +1469,7 @@ rm android-cts-media-1.5.zip</pre>
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scroll-button" class="scroll-button" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
+        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"></button>
+        {{js|/js/scroll-button.js}}
     </body>
 </html>

--- a/static/build.html
+++ b/static/build.html
@@ -28,6 +28,7 @@
         <link rel="manifest" href="/manifest.webmanifest"/>
         <link rel="license" href="/LICENSE.txt"/>
         <link rel="me" href="https://grapheneos.social/@GrapheneOS"/>
+        {{js|/js/scroll-button.js}}
     </head>
     <body>
         <header>
@@ -1469,5 +1470,6 @@ rm android-cts-media-1.5.zip</pre>
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
+        <button id="scrollButton" class="scrollButton" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
     </body>
 </html>

--- a/static/build.html
+++ b/static/build.html
@@ -1469,7 +1469,7 @@ rm android-cts-media-1.5.zip</pre>
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"/></button>
+        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg" alt="Scroll to top icon"/></button>
         {{js|/js/scroll-button.js}}
     </body>
 </html>

--- a/static/camera-privacy-policy.html
+++ b/static/camera-privacy-policy.html
@@ -89,7 +89,7 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"/></button>
+        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg" alt="Scroll to top icon"/></button>
         {{js|/js/scroll-button.js}}
     </body>
 </html>

--- a/static/camera-privacy-policy.html
+++ b/static/camera-privacy-policy.html
@@ -89,7 +89,7 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"></button>
+        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"/></button>
         {{js|/js/scroll-button.js}}
     </body>
 </html>

--- a/static/camera-privacy-policy.html
+++ b/static/camera-privacy-policy.html
@@ -28,7 +28,6 @@
         <link rel="manifest" href="/manifest.webmanifest"/>
         <link rel="license" href="/LICENSE.txt"/>
         <link rel="me" href="https://grapheneos.social/@GrapheneOS"/>
-        {{js|/js/scroll-button.js}}
     </head>
     <body>
         <header>
@@ -90,6 +89,7 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scroll-button" class="scroll-button" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
+        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"></button>
+        {{js|/js/scroll-button.js}}
     </body>
 </html>

--- a/static/camera-privacy-policy.html
+++ b/static/camera-privacy-policy.html
@@ -90,6 +90,6 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scrollButton" class="scrollButton" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
+        <button id="scroll-button" class="scroll-button" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
     </body>
 </html>

--- a/static/camera-privacy-policy.html
+++ b/static/camera-privacy-policy.html
@@ -28,6 +28,7 @@
         <link rel="manifest" href="/manifest.webmanifest"/>
         <link rel="license" href="/LICENSE.txt"/>
         <link rel="me" href="https://grapheneos.social/@GrapheneOS"/>
+        {{js|/js/scroll-button.js}}
     </head>
     <body>
         <header>
@@ -89,5 +90,6 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
+        <button id="scrollButton" class="scrollButton" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
     </body>
 </html>

--- a/static/contact.html
+++ b/static/contact.html
@@ -28,7 +28,6 @@
         <link rel="manifest" href="/manifest.webmanifest"/>
         <link rel="license" href="/LICENSE.txt"/>
         <link rel="me" href="https://grapheneos.social/@GrapheneOS"/>
-        {{js|/js/scroll-button.js}}
     </head>
     <body>
         <header>

--- a/static/contact.html
+++ b/static/contact.html
@@ -28,6 +28,7 @@
         <link rel="manifest" href="/manifest.webmanifest"/>
         <link rel="license" href="/LICENSE.txt"/>
         <link rel="me" href="https://grapheneos.social/@GrapheneOS"/>
+        {{js|/js/scroll-button.js}}
     </head>
     <body>
         <header>

--- a/static/donate.html
+++ b/static/donate.html
@@ -215,7 +215,7 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"></button>
+        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"/></button>
         {{js|/js/scroll-button.js}}
     </body>
 </html>

--- a/static/donate.html
+++ b/static/donate.html
@@ -215,7 +215,7 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"/></button>
+        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg" alt="Scroll to top icon"/></button>
         {{js|/js/scroll-button.js}}
     </body>
 </html>

--- a/static/donate.html
+++ b/static/donate.html
@@ -28,6 +28,7 @@
         <link rel="manifest" href="/manifest.webmanifest"/>
         <link rel="license" href="/LICENSE.txt"/>
         <link rel="me" href="https://grapheneos.social/@GrapheneOS"/>
+        {{js|/js/scroll-button.js}}
     </head>
     <body>
         <header>
@@ -215,5 +216,6 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
+        <button id="scrollButton" class="scrollButton" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
     </body>
 </html>

--- a/static/donate.html
+++ b/static/donate.html
@@ -28,7 +28,6 @@
         <link rel="manifest" href="/manifest.webmanifest"/>
         <link rel="license" href="/LICENSE.txt"/>
         <link rel="me" href="https://grapheneos.social/@GrapheneOS"/>
-        {{js|/js/scroll-button.js}}
     </head>
     <body>
         <header>
@@ -216,6 +215,7 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scroll-button" class="scroll-button" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
+        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"></button>
+        {{js|/js/scroll-button.js}}
     </body>
 </html>

--- a/static/donate.html
+++ b/static/donate.html
@@ -216,6 +216,6 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scrollButton" class="scrollButton" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
+        <button id="scroll-button" class="scroll-button" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
     </body>
 </html>

--- a/static/faq.html
+++ b/static/faq.html
@@ -1856,7 +1856,7 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"></button>
+        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"/></button>
         {{js|/js/scroll-button.js}}
     </body>
 </html>

--- a/static/faq.html
+++ b/static/faq.html
@@ -1856,7 +1856,7 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"/></button>
+        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg" alt="Scroll to top icon"/></button>
         {{js|/js/scroll-button.js}}
     </body>
 </html>

--- a/static/faq.html
+++ b/static/faq.html
@@ -29,7 +29,6 @@
         <link rel="license" href="/LICENSE.txt"/>
         <link rel="me" href="https://grapheneos.social/@GrapheneOS"/>
         {{js|/js/redirect.js}}
-        {{js|/js/scroll-button.js}}
     </head>
     <body>
         <header>
@@ -1857,6 +1856,7 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scroll-button" class="scroll-button" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
+        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"></button>
+        {{js|/js/scroll-button.js}}
     </body>
 </html>

--- a/static/faq.html
+++ b/static/faq.html
@@ -29,6 +29,7 @@
         <link rel="license" href="/LICENSE.txt"/>
         <link rel="me" href="https://grapheneos.social/@GrapheneOS"/>
         {{js|/js/redirect.js}}
+        {{js|/js/scroll-button.js}}
     </head>
     <body>
         <header>
@@ -1856,5 +1857,6 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
+        <button id="scrollButton" class="scrollButton" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
     </body>
 </html>

--- a/static/faq.html
+++ b/static/faq.html
@@ -1857,6 +1857,6 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scrollButton" class="scrollButton" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
+        <button id="scroll-button" class="scroll-button" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
     </body>
 </html>

--- a/static/features.html
+++ b/static/features.html
@@ -1062,7 +1062,7 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"></button>
+        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"/></button>
         {{js|/js/scroll-button.js}}
     </body>
 </html>

--- a/static/features.html
+++ b/static/features.html
@@ -28,7 +28,6 @@
         <link rel="manifest" href="/manifest.webmanifest"/>
         <link rel="license" href="/LICENSE.txt"/>
         <link rel="me" href="https://grapheneos.social/@GrapheneOS"/>
-        {{js|/js/scroll-button.js}}
     </head>
     <body>
         <header>
@@ -1063,6 +1062,7 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scroll-button" class="scroll-button" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
+        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"></button>
+        {{js|/js/scroll-button.js}}
     </body>
 </html>

--- a/static/features.html
+++ b/static/features.html
@@ -1063,6 +1063,6 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scrollButton" class="scrollButton" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
+        <button id="scroll-button" class="scroll-button" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
     </body>
 </html>

--- a/static/features.html
+++ b/static/features.html
@@ -1062,7 +1062,7 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"/></button>
+        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg" alt="Scroll to top icon"/></button>
         {{js|/js/scroll-button.js}}
     </body>
 </html>

--- a/static/features.html
+++ b/static/features.html
@@ -28,6 +28,7 @@
         <link rel="manifest" href="/manifest.webmanifest"/>
         <link rel="license" href="/LICENSE.txt"/>
         <link rel="me" href="https://grapheneos.social/@GrapheneOS"/>
+        {{js|/js/scroll-button.js}}
     </head>
     <body>
         <header>
@@ -1062,5 +1063,6 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
+        <button id="scrollButton" class="scrollButton" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
     </body>
 </html>

--- a/static/history/copperheados.html
+++ b/static/history/copperheados.html
@@ -135,7 +135,7 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"></button>
+        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"/></button>
         {{js|/js/scroll-button.js}}
     </body>
 </html>

--- a/static/history/copperheados.html
+++ b/static/history/copperheados.html
@@ -135,7 +135,7 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"/></button>
+        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg" alt="Scroll to top icon"/></button>
         {{js|/js/scroll-button.js}}
     </body>
 </html>

--- a/static/history/copperheados.html
+++ b/static/history/copperheados.html
@@ -28,7 +28,6 @@
         <link rel="manifest" href="/manifest.webmanifest"/>
         <link rel="license" href="/LICENSE.txt"/>
         <link rel="me" href="https://grapheneos.social/@GrapheneOS"/>
-        {{js|/js/scroll-button.js}}
     </head>
     <body>
         <header>
@@ -136,6 +135,7 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scroll-button" class="scroll-button" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
+        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"></button>
+        {{js|/js/scroll-button.js}}
     </body>
 </html>

--- a/static/history/copperheados.html
+++ b/static/history/copperheados.html
@@ -28,6 +28,7 @@
         <link rel="manifest" href="/manifest.webmanifest"/>
         <link rel="license" href="/LICENSE.txt"/>
         <link rel="me" href="https://grapheneos.social/@GrapheneOS"/>
+        {{js|/js/scroll-button.js}}
     </head>
     <body>
         <header>
@@ -135,5 +136,6 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
+        <button id="scrollButton" class="scrollButton" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
     </body>
 </html>

--- a/static/history/copperheados.html
+++ b/static/history/copperheados.html
@@ -136,6 +136,6 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scrollButton" class="scrollButton" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
+        <button id="scroll-button" class="scroll-button" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
     </body>
 </html>

--- a/static/history/index.html
+++ b/static/history/index.html
@@ -28,7 +28,6 @@
         <link rel="manifest" href="/manifest.webmanifest"/>
         <link rel="license" href="/LICENSE.txt"/>
         <link rel="me" href="https://grapheneos.social/@GrapheneOS"/>
-        {{js|/js/scroll-button.js}}
     </head>
     <body>
         <header>
@@ -121,6 +120,7 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scroll-button" class="scroll-button" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
+        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"></button>
+        {{js|/js/scroll-button.js}}
     </body>
 </html>

--- a/static/history/index.html
+++ b/static/history/index.html
@@ -121,6 +121,6 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scrollButton" class="scrollButton" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
+        <button id="scroll-button" class="scroll-button" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
     </body>
 </html>

--- a/static/history/index.html
+++ b/static/history/index.html
@@ -120,7 +120,7 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"></button>
+        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"/></button>
         {{js|/js/scroll-button.js}}
     </body>
 </html>

--- a/static/history/index.html
+++ b/static/history/index.html
@@ -120,7 +120,7 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"/></button>
+        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg" alt="Scroll to top icon"/></button>
         {{js|/js/scroll-button.js}}
     </body>
 </html>

--- a/static/history/index.html
+++ b/static/history/index.html
@@ -28,6 +28,7 @@
         <link rel="manifest" href="/manifest.webmanifest"/>
         <link rel="license" href="/LICENSE.txt"/>
         <link rel="me" href="https://grapheneos.social/@GrapheneOS"/>
+        {{js|/js/scroll-button.js}}
     </head>
     <body>
         <header>
@@ -120,5 +121,6 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
+        <button id="scrollButton" class="scrollButton" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
     </body>
 </html>

--- a/static/history/legacy-changelog.html
+++ b/static/history/legacy-changelog.html
@@ -28,7 +28,6 @@
         <link rel="manifest" href="/manifest.webmanifest"/>
         <link rel="license" href="/LICENSE.txt"/>
         <link rel="me" href="https://grapheneos.social/@GrapheneOS"/>
-        {{js|/js/scroll-button.js}}
     </head>
     <body>
         <header>
@@ -2197,6 +2196,7 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scroll-button" class="scroll-button" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
+        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"></button>
+        {{js|/js/scroll-button.js}}
     </body>
 </html>

--- a/static/history/legacy-changelog.html
+++ b/static/history/legacy-changelog.html
@@ -2196,7 +2196,7 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"></button>
+        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"/></button>
         {{js|/js/scroll-button.js}}
     </body>
 </html>

--- a/static/history/legacy-changelog.html
+++ b/static/history/legacy-changelog.html
@@ -2196,7 +2196,7 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"/></button>
+        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg" alt="Scroll to top icon"/></button>
         {{js|/js/scroll-button.js}}
     </body>
 </html>

--- a/static/history/legacy-changelog.html
+++ b/static/history/legacy-changelog.html
@@ -28,6 +28,7 @@
         <link rel="manifest" href="/manifest.webmanifest"/>
         <link rel="license" href="/LICENSE.txt"/>
         <link rel="me" href="https://grapheneos.social/@GrapheneOS"/>
+        {{js|/js/scroll-button.js}}
     </head>
     <body>
         <header>
@@ -2196,5 +2197,6 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
+        <button id="scrollButton" class="scrollButton" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
     </body>
 </html>

--- a/static/history/legacy-changelog.html
+++ b/static/history/legacy-changelog.html
@@ -2197,6 +2197,6 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scrollButton" class="scrollButton" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
+        <button id="scroll-button" class="scroll-button" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
     </body>
 </html>

--- a/static/index.html
+++ b/static/index.html
@@ -147,7 +147,7 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"></button>
+        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"/></button>
         {{js|/js/scroll-button.js}}
     </body>
 </html>

--- a/static/index.html
+++ b/static/index.html
@@ -29,6 +29,7 @@
         <link rel="license" href="/LICENSE.txt"/>
         <link rel="me" href="https://grapheneos.social/@GrapheneOS"/>
         {{js|/js/redirect.js}}
+        {{js|/js/scroll-button.js}}
     </head>
     <body>
         <header>
@@ -147,5 +148,6 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
+        <button id="scrollButton" class="scrollButton" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
     </body>
 </html>

--- a/static/index.html
+++ b/static/index.html
@@ -147,7 +147,7 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"/></button>
+        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg" alt="Scroll to top icon"/></button>
         {{js|/js/scroll-button.js}}
     </body>
 </html>

--- a/static/index.html
+++ b/static/index.html
@@ -148,6 +148,6 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scrollButton" class="scrollButton" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
+        <button id="scroll-button" class="scroll-button" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
     </body>
 </html>

--- a/static/index.html
+++ b/static/index.html
@@ -29,7 +29,6 @@
         <link rel="license" href="/LICENSE.txt"/>
         <link rel="me" href="https://grapheneos.social/@GrapheneOS"/>
         {{js|/js/redirect.js}}
-        {{js|/js/scroll-button.js}}
     </head>
     <body>
         <header>
@@ -148,6 +147,7 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scroll-button" class="scroll-button" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
+        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"></button>
+        {{js|/js/scroll-button.js}}
     </body>
 </html>

--- a/static/install/cli.html
+++ b/static/install/cli.html
@@ -29,7 +29,6 @@
         <link rel="license" href="/LICENSE.txt"/>
         <link rel="me" href="https://grapheneos.social/@GrapheneOS"/>
         {{js|/js/redirect.js}}
-        {{js|/js/scroll-button.js}}
     </head>
     <body>
         <header>
@@ -660,6 +659,7 @@ curl -O https://releases.grapheneos.org/<var>DEVICE_NAME</var>-factory-202111012
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scroll-button" class="scroll-button" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
+        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"></button>
+        {{js|/js/scroll-button.js}}
     </body>
 </html>

--- a/static/install/cli.html
+++ b/static/install/cli.html
@@ -29,6 +29,7 @@
         <link rel="license" href="/LICENSE.txt"/>
         <link rel="me" href="https://grapheneos.social/@GrapheneOS"/>
         {{js|/js/redirect.js}}
+        {{js|/js/scroll-button.js}}
     </head>
     <body>
         <header>
@@ -659,5 +660,6 @@ curl -O https://releases.grapheneos.org/<var>DEVICE_NAME</var>-factory-202111012
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
+        <button id="scrollButton" class="scrollButton" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
     </body>
 </html>

--- a/static/install/cli.html
+++ b/static/install/cli.html
@@ -659,7 +659,7 @@ curl -O https://releases.grapheneos.org/<var>DEVICE_NAME</var>-factory-202111012
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"></button>
+        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"/></button>
         {{js|/js/scroll-button.js}}
     </body>
 </html>

--- a/static/install/cli.html
+++ b/static/install/cli.html
@@ -660,6 +660,6 @@ curl -O https://releases.grapheneos.org/<var>DEVICE_NAME</var>-factory-202111012
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scrollButton" class="scrollButton" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
+        <button id="scroll-button" class="scroll-button" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
     </body>
 </html>

--- a/static/install/cli.html
+++ b/static/install/cli.html
@@ -659,7 +659,7 @@ curl -O https://releases.grapheneos.org/<var>DEVICE_NAME</var>-factory-202111012
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"/></button>
+        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg" alt="Scroll to top icon"/></button>
         {{js|/js/scroll-button.js}}
     </body>
 </html>

--- a/static/install/web.html
+++ b/static/install/web.html
@@ -474,7 +474,7 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"/></button>
+        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg" alt="Scroll to top icon"/></button>
         {{js|/js/scroll-button.js}}
     </body>
 </html>

--- a/static/install/web.html
+++ b/static/install/web.html
@@ -474,7 +474,7 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"></button>
+        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"/></button>
         {{js|/js/scroll-button.js}}
     </body>
 </html>

--- a/static/install/web.html
+++ b/static/install/web.html
@@ -31,6 +31,7 @@
         {{js|/js/redirect.js}}
         <script type="module" src="/js/fastboot/066d736d/fastboot.min.mjs" integrity="sha256-mH1JDLfpm9jffXPX8pRlbJtTYkMcXN7LSLXNhCM9P4E="></script>
         {{js|/js/web-install.js}}
+        {{js|/js/scroll-button.js}}
     </head>
     <body>
         <header>
@@ -474,5 +475,6 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
+        <button id="scrollButton" class="scrollButton" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
     </body>
 </html>

--- a/static/install/web.html
+++ b/static/install/web.html
@@ -31,7 +31,6 @@
         {{js|/js/redirect.js}}
         <script type="module" src="/js/fastboot/066d736d/fastboot.min.mjs" integrity="sha256-mH1JDLfpm9jffXPX8pRlbJtTYkMcXN7LSLXNhCM9P4E="></script>
         {{js|/js/web-install.js}}
-        {{js|/js/scroll-button.js}}
     </head>
     <body>
         <header>
@@ -475,6 +474,7 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scroll-button" class="scroll-button" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
+        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"></button>
+        {{js|/js/scroll-button.js}}
     </body>
 </html>

--- a/static/install/web.html
+++ b/static/install/web.html
@@ -475,6 +475,6 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scrollButton" class="scrollButton" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
+        <button id="scroll-button" class="scroll-button" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
     </body>
 </html>

--- a/static/js/scroll-button.js
+++ b/static/js/scroll-button.js
@@ -1,28 +1,2 @@
 // @license magnet:?xt=urn:btih:d3d9a9a6595521f9666a5e94cc830dab83b65699&dn=expat.txt MIT
-
-// When the user scrolls
-window.onscroll = function() {
-  showButton();
-};
-
-// Shows or hides the scroll button
-function showButton() {
-  // Get the scroll button
-  const scrollButton = document.getElementById("scroll-button");
-  // When the user scrolls down, make the scroll button visible
-  if (document.body.scrollTop > 200 || document.documentElement.scrollTop > 200) {
-      scrollButton.style.display = "block";
-  }
-  // When the user is as the top of the page, hide the scroll button
-  else {
-      scrollButton.style.display = "none";
-  }
-}
-
-// When the user clicks on the button, scroll to the top of the page
-function scrollUp() {
-  window.scrollTo({
-      top: 0,
-      behavior: "smooth"
-  });
-}
+window.onscroll=function(){showButton()};function showButton(){const scrollButton=document.getElementById("scroll-button");if(document.body.scrollTop>200||document.documentElement.scrollTop>200){scrollButton.style.display="block"}else{scrollButton.style.display="none"}}function scrollUp(){window.scrollTo({top:0,behavior:"smooth"})}

--- a/static/js/scroll-button.js
+++ b/static/js/scroll-button.js
@@ -11,7 +11,7 @@ function showButton() {
   const scrollButton = document.getElementById("scrollButton");
 
   // When the user scrolls down, make the scroll button visible
-  if (document.body.scrollTop > 20 || document.documentElement.scrollTop > 20) {
+  if (document.body.scrollTop > 200 || document.documentElement.scrollTop > 200) {
     scrollButton.style.display = "block";
   }
   // When the user is as the top of the page, hide the scroll button

--- a/static/js/scroll-button.js
+++ b/static/js/scroll-button.js
@@ -19,7 +19,9 @@ function showButton() {
     }
 }
 
-// When the user clicks on the button, scroll to the top of the page
+// When the user clicks on the button, call the scrollUp() function
+document.getElementById("scroll-button").addEventListener("click", scrollUp); 
+
 function scrollUp() {
     window.scrollTo({
         top: 0,

--- a/static/js/scroll-button.js
+++ b/static/js/scroll-button.js
@@ -1,2 +1,28 @@
 // @license magnet:?xt=urn:btih:d3d9a9a6595521f9666a5e94cc830dab83b65699&dn=expat.txt MIT
-window.onscroll=function(){showButton()};function showButton(){const scrollButton=document.getElementById("scroll-button");if(document.body.scrollTop>200||document.documentElement.scrollTop>200){scrollButton.style.display="block"}else{scrollButton.style.display="none"}}function scrollUp(){window.scrollTo({top:0,behavior:"smooth"})}
+
+// When the user scrolls
+window.onscroll = function() {
+    showButton();
+};
+
+// Shows or hides the scroll button
+function showButton() {
+    // Get the scroll button
+    const scrollButton = document.getElementById("scroll-button");
+    // When the user scrolls down, make the scroll button visible
+    if (document.body.scrollTop > 200 || document.documentElement.scrollTop > 200) {
+        scrollButton.style.display = "block";
+    }
+    // When the user is as the top of the page, hide the scroll button
+    else {
+        scrollButton.style.display = "none";
+    }
+}
+
+// When the user clicks on the button, scroll to the top of the page
+function scrollUp() {
+    window.scrollTo({
+        top: 0,
+        behavior: "smooth"
+    });
+}

--- a/static/js/scroll-button.js
+++ b/static/js/scroll-button.js
@@ -1,0 +1,29 @@
+// @license magnet:?xt=urn:btih:d3d9a9a6595521f9666a5e94cc830dab83b65699&dn=expat.txt MIT
+
+// When the user scrolls
+window.onscroll = function () {
+  showButton()
+};
+
+// Shows or hides the scroll button
+function showButton() {
+  // Get the scroll button
+  const scrollButton = document.getElementById("scrollButton");
+
+  // When the user scrolls down, make the scroll button visible
+  if (document.body.scrollTop > 20 || document.documentElement.scrollTop > 20) {
+    scrollButton.style.display = "block";
+  }
+  // When the user is as the top of the page, hide the scroll button
+  else {
+    scrollButton.style.display = "none";
+  }
+}
+
+// When the user clicks on the button, scroll to the top of the page
+function scrollUp() {
+  window.scrollTo({
+    top: 0,
+    behavior: 'smooth'
+  });
+}

--- a/static/js/scroll-button.js
+++ b/static/js/scroll-button.js
@@ -11,18 +11,18 @@ function showButton() {
   const scrollButton = document.getElementById("scroll-button");
   // When the user scrolls down, make the scroll button visible
   if (document.body.scrollTop > 200 || document.documentElement.scrollTop > 200) {
-    scrollButton.style.display = "block";
+      scrollButton.style.display = "block";
   }
   // When the user is as the top of the page, hide the scroll button
   else {
-    scrollButton.style.display = "none";
+      scrollButton.style.display = "none";
   }
 }
 
 // When the user clicks on the button, scroll to the top of the page
 function scrollUp() {
   window.scrollTo({
-    top: 0,
-    behavior: "smooth"
+      top: 0,
+      behavior: "smooth"
   });
 }

--- a/static/js/scroll-button.js
+++ b/static/js/scroll-button.js
@@ -8,7 +8,7 @@ window.onscroll = function () {
 // Shows or hides the scroll button
 function showButton() {
   // Get the scroll button
-  const scrollButton = document.getElementById("scrollButton");
+  const scrollButton = document.getElementById("scroll-button");
 
   // When the user scrolls down, make the scroll button visible
   if (document.body.scrollTop > 200 || document.documentElement.scrollTop > 200) {

--- a/static/js/scroll-button.js
+++ b/static/js/scroll-button.js
@@ -1,7 +1,7 @@
 // @license magnet:?xt=urn:btih:d3d9a9a6595521f9666a5e94cc830dab83b65699&dn=expat.txt MIT
 
 // When the user scrolls
-window.onscroll = function () {
+window.onscroll = function() {
   showButton();
 };
 
@@ -9,7 +9,6 @@ window.onscroll = function () {
 function showButton() {
   // Get the scroll button
   const scrollButton = document.getElementById("scroll-button");
-
   // When the user scrolls down, make the scroll button visible
   if (document.body.scrollTop > 200 || document.documentElement.scrollTop > 200) {
     scrollButton.style.display = "block";

--- a/static/js/scroll-button.js
+++ b/static/js/scroll-button.js
@@ -2,7 +2,7 @@
 
 // When the user scrolls
 window.onscroll = function () {
-  showButton()
+  showButton();
 };
 
 // Shows or hides the scroll button
@@ -24,6 +24,6 @@ function showButton() {
 function scrollUp() {
   window.scrollTo({
     top: 0,
-    behavior: 'smooth'
+    behavior: "smooth"
   });
 }

--- a/static/main.css
+++ b/static/main.css
@@ -194,6 +194,15 @@ button:disabled {
     line-height: 2.5rem;
 }
 
+button.scrollButton {
+    display: none;
+    padding: 0.5rem 0.5rem;
+    position: fixed;
+    bottom: 20px;
+    right: 30px;
+    z-index: 99;
+}
+
 .coin-address {
     display: block;
     margin-left: auto;

--- a/static/main.css
+++ b/static/main.css
@@ -194,9 +194,9 @@ button:disabled {
     line-height: 2.5rem;
 }
 
-button.scrollButton {
+button.scroll-button {
     display: none;
-    padding: 0.5rem 0.5rem;
+    padding: 0.5rem;
     position: fixed;
     bottom: 20px;
     right: 30px;

--- a/static/releases.html
+++ b/static/releases.html
@@ -6296,7 +6296,7 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"></button>
+        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"/></button>
         {{js|/js/scroll-button.js}}
     </body>
 </html>

--- a/static/releases.html
+++ b/static/releases.html
@@ -6297,6 +6297,6 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scrollButton" class="scrollButton" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
+        <button id="scroll-button" class="scroll-button" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
     </body>
 </html>

--- a/static/releases.html
+++ b/static/releases.html
@@ -31,6 +31,7 @@
         <link rel="me" href="https://grapheneos.social/@GrapheneOS"/>
         {{js|/js/releases.js}}
         {{js|/js/redirect.js}}
+        {{js|/js/scroll-button.js}}
     </head>
     <body>
         <header>
@@ -6296,5 +6297,6 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
+        <button id="scrollButton" class="scrollButton" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
     </body>
 </html>

--- a/static/releases.html
+++ b/static/releases.html
@@ -6296,7 +6296,7 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"/></button>
+        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg" alt="Scroll to top icon"/></button>
         {{js|/js/scroll-button.js}}
     </body>
 </html>

--- a/static/releases.html
+++ b/static/releases.html
@@ -31,7 +31,6 @@
         <link rel="me" href="https://grapheneos.social/@GrapheneOS"/>
         {{js|/js/releases.js}}
         {{js|/js/redirect.js}}
-        {{js|/js/scroll-button.js}}
     </head>
     <body>
         <header>
@@ -6297,6 +6296,7 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scroll-button" class="scroll-button" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
+        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"></button>
+        {{js|/js/scroll-button.js}}
     </body>
 </html>

--- a/static/scroll-arrow.svg
+++ b/static/scroll-arrow.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#FFFFFF"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M4 12l1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z"/></svg>

--- a/static/source.html
+++ b/static/source.html
@@ -24,17 +24,17 @@
         <link rel="icon" sizes="any" type="image/svg+xml" href="/favicon.svg"/>
         <link rel="mask-icon" href="{{path|/mask-icon.svg}}" color="#1a1a1a"/>
         <link rel="apple-touch-icon" href="/apple-touch-icon.png"/>
-        {{css|/main.css}}
+        <link rel="stylesheet" href="./main.css">
         <link rel="manifest" href="/manifest.webmanifest"/>
         <link rel="license" href="/LICENSE.txt"/>
         <link rel="me" href="https://grapheneos.social/@GrapheneOS"/>
-        {{js|/js/scroll-button.js}}
+        <script src="./js/scroll-button.js"></script>
     </head>
     <body>
         <header>
             <nav id="site-menu">
                 <ul>
-                    <li><a href="/"><img src="{{path|/mask-icon.svg}}" alt=""/>GrapheneOS</a></li>
+                    <li><a href="/"><img src="mask-icon.svg" alt=""/>GrapheneOS</a></li>
                     <li><a href="/features">Features</a></li>
                     <li><a href="/install/">Install</a></li>
                     <li><a href="/build">Build</a></li>
@@ -308,6 +308,6 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scrollButton" class="scrollButton" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
+        <button id="scroll-button" class="scroll-button" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
     </body>
 </html>

--- a/static/source.html
+++ b/static/source.html
@@ -307,7 +307,7 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"></button>
+        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"/></button>
         {{js|/js/scroll-button.js}}
     </body>
 </html>

--- a/static/source.html
+++ b/static/source.html
@@ -28,6 +28,7 @@
         <link rel="manifest" href="/manifest.webmanifest"/>
         <link rel="license" href="/LICENSE.txt"/>
         <link rel="me" href="https://grapheneos.social/@GrapheneOS"/>
+        {{js|/js/scroll-button.js}}
     </head>
     <body>
         <header>
@@ -307,5 +308,6 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
+        <button id="scrollButton" class="scrollButton" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
     </body>
 </html>

--- a/static/source.html
+++ b/static/source.html
@@ -24,11 +24,10 @@
         <link rel="icon" sizes="any" type="image/svg+xml" href="/favicon.svg"/>
         <link rel="mask-icon" href="{{path|/mask-icon.svg}}" color="#1a1a1a"/>
         <link rel="apple-touch-icon" href="/apple-touch-icon.png"/>
-        <link rel="stylesheet" href="./main.css">
+        {{css|/main.css}}
         <link rel="manifest" href="/manifest.webmanifest"/>
         <link rel="license" href="/LICENSE.txt"/>
         <link rel="me" href="https://grapheneos.social/@GrapheneOS"/>
-        <script src="./js/scroll-button.js"></script>
     </head>
     <body>
         <header>
@@ -308,6 +307,7 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scroll-button" class="scroll-button" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
+        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"></button>
+        {{js|/js/scroll-button.js}}
     </body>
 </html>

--- a/static/source.html
+++ b/static/source.html
@@ -307,7 +307,7 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"/></button>
+        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg" alt="Scroll to top icon"/></button>
         {{js|/js/scroll-button.js}}
     </body>
 </html>

--- a/static/usage.html
+++ b/static/usage.html
@@ -1300,7 +1300,7 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"></button>
+        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"/></button>
         {{js|/js/scroll-button.js}}
     </body>
 </html>

--- a/static/usage.html
+++ b/static/usage.html
@@ -29,7 +29,6 @@
         <link rel="license" href="/LICENSE.txt"/>
         <link rel="me" href="https://grapheneos.social/@GrapheneOS"/>
         {{js|/js/redirect.js}}
-        {{js|/js/scroll-button.js}}
     </head>
     <body>
         <header>
@@ -1301,6 +1300,7 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scroll-button" class="scroll-button" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
+        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"></button>
+        {{js|/js/scroll-button.js}}
     </body>
 </html>

--- a/static/usage.html
+++ b/static/usage.html
@@ -1301,6 +1301,6 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scrollButton" class="scrollButton" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
+        <button id="scroll-button" class="scroll-button" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
     </body>
 </html>

--- a/static/usage.html
+++ b/static/usage.html
@@ -29,6 +29,7 @@
         <link rel="license" href="/LICENSE.txt"/>
         <link rel="me" href="https://grapheneos.social/@GrapheneOS"/>
         {{js|/js/redirect.js}}
+        {{js|/js/scroll-button.js}}
     </head>
     <body>
         <header>
@@ -1300,5 +1301,6 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
+        <button id="scrollButton" class="scrollButton" onclick="scrollUp()"><img src="./scroll-arrow.svg"></button>
     </body>
 </html>

--- a/static/usage.html
+++ b/static/usage.html
@@ -1300,7 +1300,7 @@
                 <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
             </ul>
         </footer>
-        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg"/></button>
+        <button id="scroll-button" class="scroll-button"><img src="./scroll-arrow.svg" alt="Scroll to top icon"/></button>
         {{js|/js/scroll-button.js}}
     </body>
 </html>


### PR DESCRIPTION
This adds a scroll-to-top button to most pages of the site.

This change will make navigating the site less tedious. For example, with the current behavior, if you scroll far down on a long page it's tedious to have to manually scroll all the way back to the top (especially on mobile).
The scroll-to-top button fixes this issue by automatically scrolling to the top of the page when tapped. It uses the same styling as other buttons from the site.

Demonstration:

https://github.com/GrapheneOS/grapheneos.org/assets/123981212/54e4707e-33a3-428b-84d2-06600784d0d4


