### PR TITLE
Standardize the size of the QR codes on the Donate page

### DIFF
--- a/static/donate.html
+++ b/static/donate.html
@@ -90,7 +90,7 @@
 
                 <div class="coin-address">
                     <a href="bitcoin:bc1qy6fhm8p00p3h3w5rrcp2h2wejeeqn7x6y7xs2p?label=GrapheneOS&amp;message=Donation%20to%20GrapheneOS" rel="nofollow">
-                        <img src="/donate-bitcoin.png" alt="Bitcoin donation QR code" width="180" height="180"/>
+                        <img src="/donate-bitcoin.png" alt="Bitcoin donation QR code"/>
                         <p>bc1qy6fhm8p00p3h3w5rrcp2h2wejeeqn7x6y7xs2p</p>
                     </a>
                 </div>
@@ -99,7 +99,7 @@
 
                 <div class="coin-address">
                     <a href="bitcoin:bc1paundtwscvlqchmjgds2cj2dpay5y72ll37r07x57dhw9q234k6dqmc2ztx?label=GrapheneOS&amp;message=Donation%20to%20GrapheneOS" rel="nofollow">
-                        <img src="/donate-bitcoin-taproot.png" alt="Bitcoin Taproot donation QR code" width="196" height="196"/>
+                        <img src="/donate-bitcoin-taproot.png" alt="Bitcoin Taproot donation QR code"/>
                         <p>bc1paundtwscvlqchmjgds2cj2dpay5y72ll37r07x57dhw9q234k6dqmc2ztx</p>
                     </a>
                 </div>
@@ -116,7 +116,7 @@
 
                 <div class="coin-address">
                     <a href="monero:8BHhJ3AnnZUJu4JYHasUus6Tq4HYyhiYRgrJAKNtfPc2hKMrTzbeUuf3B8ojtFMAu5MjNEDhoFQ31QLhs2z46CYDTUnuN63?recipient_name=GrapheneOS&amp;tx_description=Donation%20to%20GrapheneOS" rel="nofollow">
-                        <img src="/donate-monero.png" alt="Monero donation QR code" width="228" height="228"/>
+                        <img src="/donate-monero.png" alt="Monero donation QR code"/>
                         <p>8BHhJ3AnnZUJu4JYHasUus6Tq4HYyhiYRgrJAKNtfPc2hKMrTzbeUuf3B8ojtFMAu5MjNEDhoFQ31QLhs2z46CYDTUnuN63</p>
                     </a>
                 </div>
@@ -139,7 +139,7 @@
 
                 <div class="coin-address">
                     <a href="zcash:t1dsDbZQZrEUEGanmPMTAGxY2PJowL2S4br?label=GrapheneOS&amp;message=Donation%20to%20GrapheneOS" rel="nofollow">
-                        <img src="/donate-zcash-transparent.png" alt="Transparent Zcash donation QR code" width="180" height="180"/>
+                        <img src="/donate-zcash-transparent.png" alt="Transparent Zcash donation QR code"/>
                         <p>t1dsDbZQZrEUEGanmPMTAGxY2PJowL2S4br</p>
                     </a>
                 </div>
@@ -152,7 +152,7 @@
 
                 <div class="coin-address">
                     <a href="ethereum:0xb74eD3BE17C0F2AF46AC6F15b0536d6D112D1A8c" rel="nofollow">
-                        <img src="/donate-ethereum.png" alt="Ethereum donation QR code" width="148" height="148"/>
+                        <img src="/donate-ethereum.png" alt="Ethereum donation QR code"/>
                         <p>0xb74eD3BE17C0F2AF46AC6F15b0536d6D112D1A8c</p>
                     </a>
                 </div>
@@ -167,7 +167,7 @@
 
                 <div class="coin-address">
                     <a href="web+cardano:addr1q9yy48cu957rgmsh7s355gm458vauqll0z56r7gehqge8sv29gwxlt6f8pavhx2hjuw6494sxny8te7lrs0c6237u9ps443gd6" rel="nofollow">
-                        <img src="/donate-cardano.png" alt="Cardano donation QR code" width="196" height="196"/>
+                        <img src="/donate-cardano.png" alt="Cardano donation QR code"/>
                         <p>addr1q9yy48cu957rgmsh7s355gm458vauqll0z56r7gehqge8sv29gwxlt6f8pavhx2hjuw6494sxny8te7lrs0c6237u9ps443gd6</p>
                     </a>
                 </div>

--- a/static/main.css
+++ b/static/main.css
@@ -203,6 +203,9 @@ button:disabled {
 
 .coin-address img {
     image-rendering: pixelated;
+    width: 180px;
+    height: 180px;
+    border-radius: 16px;
 }
 
 footer img {


### PR DESCRIPTION
This saves space on the page and improves consistency.
Also adds a slight curve to the corners of the QR codes.

Before:
<img src="https://github.com/GrapheneOS/grapheneos.org/assets/123981212/a5c466b6-e678-4269-ae7f-765cef2b7c70" width="50%">

After:
<img src="https://github.com/GrapheneOS/grapheneos.org/assets/123981212/2defd6aa-3f33-4de3-9948-572dd28245b4" width="50%">
