### PR TITLE
feat: improve DX, add minimal dev server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,34 @@
+# GrapheneOS.org
+
+Source of https://grapheneos.org/
+
+## Setup
+Install dependencies
+
+```bash
+# Debian/Ubuntu
+$ apt-get install libxml2-utils yajl-tools moreutils parallel zopfli brotli default-jre
+```
+
+Clone repo & run setup
+```bash
+$ git clone https://github.com/GrapheneOS/grapheneos.org
+$ ./setup
+```
+
+## Development server
+
+First make sure that flask is installed (it's not listed in requirements as it's a development only dependency)
+
+```bash
+$ pip3 install flask
+```
+
+Then run the server
+```bash
+# Start the dev server on localhost:5000
+$ ./dev-server
+# or
+$ ./dev-server --host 0.0.0.0 --port 3000
+```
+

--- a/dev-server
+++ b/dev-server
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""
+Simple Flask dev server for grapheneos.org
+
+This is a bare-minimum dev server to improve DX by generating & reloading
+page templates on the fly. Note that there is no HMR (Hot Module Reloading)
+so you need to refresh the page in the browser manually
+"""
+from os.path import exists, join
+from flask import Flask, send_from_directory, render_template
+import argparse
+import re
+
+def resourcerepl(match):
+    """
+    Regex callable to replace matched template strings with html
+    """
+    resourcetype = match.group(1)
+    pathname = match.group(2)
+
+    if resourcetype == 'js':
+        return '<script src="' + pathname + '"></script>'
+    elif resourcetype == 'css':
+        return '<link rel="stylesheet" href="' + pathname + '">'
+    elif resourcetype == 'path':
+        return pathname
+    else:
+        raise Exception('Unsupported resource type:' + resourcetype)
+
+app = Flask(
+    __name__,
+    #static_url_path='', 
+    #static_folder='static',
+    template_folder='templates'
+    )
+
+@app.route("/", defaults={'path': ''})
+@app.route("/<path:path>", methods=["GET"])
+def get(path):
+    orig_path = path
+    try_template = False
+
+    # Home / index has empty path
+    if not path:
+        try_template = True
+        path = "index.html"
+    # Assume that anything with a dot in the request path is a request for a static file
+    elif "." not in path:
+        # Match without trailing slash (ie /faq)
+        if exists(join('templates', 'pages', path + '.html')):
+            try_template = True
+            path += ".html"
+        # Match with trailing slash (ie /faq/)
+        elif exists(join('templates', 'pages', path + "index.html")):
+            try_template = True
+            path += "index.html"
+
+    if try_template:
+        current_page = orig_path.rstrip('/') # TODO: sanitize
+        html = render_template(join("pages", path), current_page=current_page)
+
+        # Replace generated resources in html
+        html = re.sub(r'\[\[(css|js|path)\|(.*?)\]\]', resourcerepl, html)
+        return html
+
+    return send_from_directory('static', path)
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser("./dev.py")
+    # Debugger is enabled by default to support auto reloading
+    parser.add_argument("--debug", help="Start debugger", type=bool, default=True)
+    parser.add_argument("--host", help="Interface to listen on", type=str, default='')
+    parser.add_argument("--port", help="Port to listen on", type=int, default=5000)
+    args = parser.parse_args()
+
+    app.jinja_env.auto_reload = True
+    app.config['TEMPLATES_AUTO_RELOAD'] = True
+    app.run(debug=args.debug, host=args.host, port=args.port)


### PR DESCRIPTION
### ❗ This PR should only be merged after #727 is merged

> As requested by @maade69 in https://github.com/GrapheneOS/grapheneos.org/pull/728, a separate PR to improve DX

Preferably this project would use one of the many readily available static site generators (SSG) for a SPA which would probably come with a full fledged dev server already. But as I was told that would be a step too far for now I've created this minimal dev server so that we at least can easily work on the new jinja templates

The dev server is based on [Flask](https://flask.palletsprojects.com/), which is made by the same developers as Jinja is. Flask needs to be installed manually (`pip3 install flask`), I did not add it to requirements. If we add more dev requirements it might make sense to add a separate requirements file

## Features

- Automatically searches any given path for a corresponding html file, ie given a request pathname of `/about` it will look for a file named `./templates/pages/about.html` or `./templates/pages/about/index.html`. If that file exists, then that html file is rendered to html
- Supports replacements of scripts, styles & other resources. The html files are using a syntax like `[[js/path/to/file.js]]` to include/load external files in the html. The dev-server supports this syntax to load the original source files
- If no corresponding html template is found for a given path, then we'll assume it's a resource file and will try to load the path from the `./static` folder

## Not implemented or planned
If we would like to support any of the below features it would probably make more sense to use a readily available SSG
- No Hot Module Reloading (HMR), the dev server by default reloads automatically if you change a file on disk but you have to manually refresh the page in your browser
- No code splitting
- No SPA support



