### PR TITLE
Correct maximum standard tier amount for GitHub Sponsors

### DIFF
--- a/static/donate.html
+++ b/static/donate.html
@@ -66,7 +66,7 @@
 
                 <p>GrapheneOS can be sponsored with recurring or one-time donations via credit
                 cards through <a href="https://github.com/sponsors/thestinger">GitHub
-                Sponsors</a>. There are standard tiers from $5 to $250 or you can donate a custom
+                Sponsors</a>. There are standard tiers from $5 to $5,000 or you can donate a custom
                 amount.</p>
             </section>
 


### PR DESCRIPTION
The current maximum standard tier that shows up at https://github.com/sponsors/thestinger is $5,000.

This PR corrects the text on the donation page which currently says that the max is $250.