### PR TITLE
Mention forum as another alternative to r/GrapheneOS

### DIFF
--- a/static/contact.html
+++ b/static/contact.html
@@ -113,7 +113,7 @@
                 <p>The official subreddit is
                 <a href="https://reddit.com/r/GrapheneOS">/r/GrapheneOS</a>. The subreddit is
                 currently primarily used for announcements and you should use the Matrix
-                rooms to seek support or participate in the community.</p>
+                rooms or our discussion forum to seek support or participate in the community.</p>
             </section>
 
             <section id="contacting-the-project">


### PR DESCRIPTION
This PR also mentions the discussion forum instead of just the Matrix rooms as an alternative to the r/GrapheneOS subreddit, which is discouraged as a way to engage with the community.