### PR TITLE
Remove archived repos, add missing repo to source page

### DIFF
--- a/static/source.html
+++ b/static/source.html
@@ -127,7 +127,6 @@
                     <li><a href="https://github.com/GrapheneOS/platform_libcore">platform_libcore</a></li>
                     <li><a href="https://github.com/GrapheneOS/platform_manifest">platform_manifest</a>: Manifest for OS repositories</li>
                     <li><a href="https://github.com/GrapheneOS/platform_packages_apps_Calendar">platform_packages_apps_Calendar</a></li>
-                    <li><a href="https://github.com/GrapheneOS/platform_packages_apps_CarrierConfig">platform_packages_apps_CarrierConfig</a></li>
                     <li><a href="https://github.com/GrapheneOS/platform_packages_apps_CellBroadcastReceiver">platform_packages_apps_CellBroadcastReceiver</a></li>
                     <li><a href="https://github.com/GrapheneOS/platform_packages_apps_Contacts">platform_packages_apps_Contacts</a></li>
                     <li><a href="https://github.com/GrapheneOS/platform_packages_apps_DeskClock">platform_packages_apps_DeskClock</a></li>
@@ -211,8 +210,8 @@
                 <ul>
                     <li><a href="https://github.com/GrapheneOS/adevtool">adevtool</a></li>
                     <li><a href="https://github.com/GrapheneOS/branding">branding</a></li>
-                    <li><a href="https://github.com/GrapheneOS/carriersettings-extractor">carriersettings-extractor</a></li>
                     <li><a href="https://github.com/GrapheneOS/hardened_malloc">hardened_malloc</a></li>
+                    <li><a href="https://github.com/GrapheneOS/platform_packages_apps_CarrierConfig2">platform_packages_apps_CarrierConfig2</a></li>
                     <li><a href="https://github.com/GrapheneOS/platform_external_Apps">platform_external_Apps</a>: Apps app prebuilt</li>
                     <li><a href="https://github.com/GrapheneOS/platform_external_Auditor">platform_external_Auditor</a>: Auditor app prebuilt</li>
                     <li><a href="https://github.com/GrapheneOS/platform_external_Camera">platform_external_Camera</a>: Camera app prebuilt</li>


### PR DESCRIPTION
carriersettings-extractor and platform_packages_apps_CarrierConfig have been archived, so they've been removed.

platform_packages_apps_CarrierConfig2 has been added to the list.
