### PR TITLE
Qualify Verizon Devices as Unsupported Due to OEM Unlock

### DIFF
--- a/static/faq.html
+++ b/static/faq.html
@@ -190,6 +190,8 @@
                     and Bionic along with easily added support for other environments. It can easily run
                     on non-Linux-based operating systems too, and supporting some like HardenedBSD is
                     planned but depends on contributors from those communities.</p>
+
+                    <p>Verizon devices are not supported. They do not allow "OEM unlocking" which is required during the installtion process. If buying used, you can use the IMEI number to check if it is a Verizon device <a href="https://store.google.com/repair">here</a>.</p>
                 </article>
 
                 <article id="recommended-devices">

--- a/static/faq.html
+++ b/static/faq.html
@@ -191,7 +191,10 @@
                     on non-Linux-based operating systems too, and supporting some like HardenedBSD is
                     planned but depends on contributors from those communities.</p>
 
-                    <p>Verizon devices are not supported. They do not allow "OEM unlocking" which is required during the installtion process. If buying used, you can use the IMEI number to check if it is a Verizon device <a href="https://store.google.com/repair">here</a>.</p>
+                    <p>Verizon devices are not supported. They do not allow "OEM unlocking" which is 
+                    required during the installtion process. If buying used, you can use the IMEI number 
+                    to check if it is a Verizon device <a href="https://store.google.com/repair">here</a>.
+                    </p>
                 </article>
 
                 <article id="recommended-devices">


### PR DESCRIPTION
Verizon Pixels do not support "OEM Unlocking". Even if they are carrier unlocked. This prevents the user from installing GrapheneOS .

There are no known workarounds or cases were Verizon has lifted the lock.