### PR TITLE
Update supported device list and move Pixel 5 entry to EOL section.

### DIFF
--- a/static/faq.html
+++ b/static/faq.html
@@ -140,7 +140,6 @@
                         <li>Pixel 6 Pro (raven)</li>
                         <li>Pixel 6 (oriole)</li>
                         <li>Pixel 5a (barbet)</li>
-                        <li>Pixel 5 (redfin)</li>
                         <li>Pixel 4a (5G) (bramble)</li>
                     </ul>
 
@@ -148,6 +147,7 @@
                     updates and are supported via extended support releases of GrapheneOS:</p>
 
                     <ul>
+                        <li>Pixel 5 (redfin)</li>
                         <li>Pixel 4a (sunfish)</li>
                         <li>Pixel 4 XL (coral)</li>
                         <li>Pixel 4 (flame)</li>


### PR DESCRIPTION
The end of life for the Pixel 5, was yesterday, October 14, 2023.