### PR TITLE
Remove outdated instructions for production build at 6th and 7th gen …

### DIFF
--- a/static/build.html
+++ b/static/build.html
@@ -471,14 +471,6 @@ m aapt2</pre>
 
                     <pre>m target-files-package</pre>
 
-                    <p>For the Pixel 6, Pixel 6 Pro and Pixel 6a you currently need <code>m
-                    vendorbootimage target-files-package</code> instead of
-                    <code>target-files-package</code>.</p>
-
-                    <p>For the Pixel 7, Pixel 7 Pro, Pixel 7a, Pixel Tablet and Pixel Fold you
-                    currently need <code>m vendorbootimage vendorkernelbootimage
-                    target-files-package</code> instead of <code>target-files-package</code>.</p>
-
                     <p>The <code>-j</code> parameter can be passed to <code>m</code> to set a specific
                     number of jobs such as <code>-j4</code> to use 4 jobs. By default, the build system
                     sets the number of jobs to <code>NumCPU() + 2</code> where <code>NumCPU()</code> is the


### PR DESCRIPTION
…Pixels

These aren't needed as of building with AOSP 14 as base