### PR TITLE
Make buttons inherit font family

### DIFF
--- a/static/main.css
+++ b/static/main.css
@@ -159,6 +159,10 @@ main {
     overflow-wrap: break-word;
 }
 
+button, input, select, textarea {
+    font-family: inherit;
+}
+
 button, .button, .button:visited {
     color: white;
     font-size: 0.9em;


### PR DESCRIPTION
Form elements don't inherit fonts by default. This causes ```<button>``` elements to have a browser-chosen font unlike the ```<a>``` element that looks like a button in the home page.
Also, if desired, ```<input>```, ```<select>```, and ```<textarea>``` elements, which have the same behavior, can be added to the CSS rule as well.

**Home page button (actually an ```<a>``` element) (https://grapheneos.org/)**
![image1](https://github.com/GrapheneOS/grapheneos.org/assets/126974221/db641633-37f9-4f82-8961-599b77771da9)
**Buttons in the web installer page (https://grapheneos.org/install/web)**
![image2](https://github.com/GrapheneOS/grapheneos.org/assets/126974221/d37a17d4-040c-4ce8-bc56-0a02c6b2f344)
**These are actually different fonts**
![image3](https://github.com/GrapheneOS/grapheneos.org/assets/126974221/8e5c2cc4-4e00-4d66-bdf1-f3cbb211630c)
![image4](https://github.com/GrapheneOS/grapheneos.org/assets/126974221/5eae3cec-f9bd-4cc5-8596-7676a76c93aa)

Reference: https://stackoverflow.com/questions/26140050/why-is-font-family-not-inherited-in-button-tags-automatically