### PR TITLE
Fix typo in fwupd section

### DIFF
--- a/static/install/cli.html
+++ b/static/install/cli.html
@@ -307,7 +307,7 @@ Installed as /home/username/platform-tools/fastboot</pre>
                 ChromeOS) has <a href="https://github.com/fwupd/fwupd/issues/6437">a bug breaking
                 connecting to fastboot devices</a>. The web installer takes slightly longer to
                 connect to the device and is more impacted by this. If you're on a Linux
-                distribution with fwupd running, stop uit before proceeding. You can do this by
+                distribution with fwupd running, stop it before proceeding. You can do this by
                 running the following command in a terminal:</p>
 
                 <pre>sudo systemctl stop fwupd.service</pre>

--- a/static/install/web.html
+++ b/static/install/web.html
@@ -196,7 +196,7 @@
                 ChromeOS) has <a href="https://github.com/fwupd/fwupd/issues/6437">a bug breaking
                 connecting to fastboot devices</a>. The web installer takes slightly longer to
                 connect to the device and is more impacted by this. If you're on a Linux
-                distribution with fwupd running, stop uit before proceeding. You can do this by
+                distribution with fwupd running, stop it before proceeding. You can do this by
                 running the following command in a terminal:</p>
 
                 <pre>sudo systemctl stop fwupd.service</pre>


### PR DESCRIPTION
This fixes a small typo in the CLI and web install guides, in the section for the workaround regarding fwupd.

uit -> it