### PR TITLE
add low storage warning banner

### DIFF
--- a/static/install/web.html
+++ b/static/install/web.html
@@ -35,6 +35,19 @@
     <body>
         {% include "header.html" %}
         <main id="web-install">
+            <p id="sticky-error-text" hidden="hidden">
+                Your browser reports that your device doesn't have enough free storage space to install GrapheneOS (needed: 32 gigabytes). 
+                This may be caused by insufficient storage being free on your device, or by some artificial restriction, 
+                such as an "Incognito mode" tab or an "InPrivate Window". Please close this tab/window, 
+                then check that your device has enough free storage space, then start over, without "Incognito mode", "InPrivate Window", etc. 
+                Also, please check that all necessary <a href="#prerequisites">prerequisites</a> are satisfied.
+            </p>
+            <p id="sticky-error-text-brave" hidden="hidden">
+                The Shields function of the Brave browser restricts the amount of file storage that a web page can use. 
+                This will cause the installer to fail. If you have not disabled Shields for this web site, 
+                please close this window, disable Shields for this site, and start over. 
+                Also, please check that all necessary <a href="#prerequisites">prerequisites</a> are satisfied.
+            </p>
             <h1><a href="#web-install">Web installer</a></h1>
 
             <p>This is the WebUSB-based installer for GrapheneOS and is the recommended approach

--- a/static/js/web-install.js
+++ b/static/js/web-install.js
@@ -447,4 +447,20 @@ window.addEventListener("beforeunload", event => {
     }
 });
 
+const isBrave = navigator.brave !== undefined && await navigator.brave.isBrave();
+if (isBrave) {
+    const elementError = document.getElementById("sticky-error-text-brave");
+    elementError.hidden = false;
+}
+
+const estimatedStorage = await navigator.storage.estimate();
+const estimatedStorageInGB = (estimatedStorage.quota / 1024 / 1024 / 1024).toFixed(2);
+const MIN_FREE_STORAGE_REQUIRED_IN_GB = 32.0;
+
+if (!isBrave && "usb" in navigator && MIN_FREE_STORAGE_REQUIRED_IN_GB > estimatedStorageInGB) {
+    const elementError = document.getElementById("sticky-error-text");
+    elementError.hidden = false;
+}
+console.log(`Free storage : ${estimatedStorageInGB}`);
+
 // @license-end

--- a/static/main.css
+++ b/static/main.css
@@ -264,6 +264,19 @@ footer a, footer a:visited {
     color: #b00020;
 }
 
+#sticky-error-text {
+    background-color: #b00020;
+    border-radius: 0.5rem;
+    color: white;
+    padding: 1rem;
+}
+
+#sticky-error-text-brave {
+    background-color: #F96;
+    border-radius: 0.5rem;
+    padding: 1rem;
+}
+
 table {
     border-collapse: collapse;
     width: 100%;


### PR DESCRIPTION
Tested on Mac, Windows, Linux and Android with all three supported browser Chrome, Edge and Brave.