### PR TITLE
Add Bluesky project account to contact page and footer

### DIFF
--- a/static/contact.html
+++ b/static/contact.html
@@ -169,6 +169,9 @@
 
                 <p>The official Mastodon account for the project is <a href="https://grapheneos.social/@GrapheneOS">@GrapheneOS@grapheneos.social</a>
                 which is used for official announcements.</p>
+
+                <p>The official Bluesky account for the project is <a href="https://bsky.app/profile/grapheneos.org">@grapheneos.org</a>
+                which is used for official announcements.</p>
             </section>
 
             <section id="hiring">
@@ -248,7 +251,8 @@
                     "https://www.youtube.com/@GrapheneOS",
                     "https://g.page/r/CeQbRTxotybUEAE",
                     "https://en.wikipedia.org/wiki/GrapheneOS",
-                    "https://www.wikidata.org/wiki/Q85764357"
+                    "https://www.wikidata.org/wiki/Q85764357",
+                    "https://bsky.app/profile/grapheneos.org"
                 ],
                 "foundingDate": "2014"
             }

--- a/templates/footer.html
+++ b/templates/footer.html
@@ -7,6 +7,7 @@
         <li><a href="https://grapheneos.org/hiring">Hiring</a></li>
         <li><a href="https://twitter.com/GrapheneOS">Twitter</a></li>
         <li><a href="https://grapheneos.social/@GrapheneOS">Mastodon</a></li>
+        <li><a href="https://bsky.app/profile/grapheneos.org">Bluesky</a></li>
         <li><a href="https://github.com/GrapheneOS">GitHub</a></li>
         <li><a href="https://reddit.com/r/GrapheneOS">Reddit</a></li>
         <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>


### PR DESCRIPTION
Bluesky accounts can now be viewed without an account required, so the invite-only nature of Bluesky should no longer be a blocker to it being listed.