### PR TITLE
Warn eSIM users to keep PUKs handy to avoid device lockout (as reported in OS issue 2162)

### DIFF
--- a/static/usage.html
+++ b/static/usage.html
@@ -1123,6 +1123,19 @@
                     "Checking network info..." stage despite having a stable Internet connection,
                     you may need to call the USSD code <code>*#*#4636#*#*</code> and then enable
                     DSDS in the menu that is presented.</p>
+
+                    <!-- https://github.com/GrapheneOS/os-issue-tracker/issues/2162 -->
+                    <p><strong>Warning:</strong> Do not enable a PIN for an eSIM without first
+                    memorizing the eSIM's
+                    <a href="https://en.wikipedia.org/wiki/Personal_unblocking_key">PUK</a>.
+                    If you do not know your eSIM's PUK, you may be forced to factory-reset
+                    your device (<strong>thus wiping your data</strong>) to reinstall the
+                    stock OS, as follows. GrapheneOS automatically disables the proprietary
+                    Google eSIM management code on every reboot. If an eSIM has locked itself
+                    because an incorrect PIN has been entered multiple times, it will not be
+                    possible to disable the eSIM on the boot-time SIM-unlock screen.  Without
+                    the PUK it will not be possible to unlock the device, access Settings,
+                    enable the proprietary Google eSIM management code, and disable the eSIM.</p>
                 </section>
             </section>
 


### PR DESCRIPTION
This warns eSIM users to obtain and memorize the PUK to avoid being locked out of the device at boot time, as reported by three users in https://github.com/GrapheneOS/os-issue-tracker/issues/2162 and also as discussed in [forum thread 9854](https://discuss.grapheneos.org/d/9854-gos-phone-unusable-after-forgetting-esim-pin-due-to-google-esim-management/14).