### PR TITLE
Lower default auto-reboot timer to 18 hours

### DIFF
--- a/static/releases.html
+++ b/static/releases.html
@@ -730,6 +730,7 @@
                         <li>reimplement our user-facing crash reporting infrastructure with our new log viewer app</li>
                         <li>Settings: add links to log viewer in app info and system settings</li>
                         <li>show report button in sandboxed Google Play crash report UI</li>
+                        <li>Lower default timer of atuo-reboot setting from 72 hours to 18 hours</li>
                         <li>adevtool: improve and clean up infrastructure for device support</li>
                         <li>adevtool: integrate support for Pixel Camera Services (currently provides Night mode for GrapheneOS Camera and other apps on Pixel 6 and later)</li>
                         <li>adevtool: drop devices not supported with Android 14</li>


### PR DESCRIPTION
This PR adds a chagelog entry for https://github.com/GrapheneOS/platform_frameworks_base/commit/2d05c8276f21f37c9dd13205fc72a60dd7ca7048.