### PR TITLE
Change default auto reboot timer in features page

### DIFF
--- a/static/features.html
+++ b/static/features.html
@@ -725,7 +725,8 @@
 
                     <p>Option to enable automatically rebooting the device when no profile has
                     been unlocked for the configured time period to put the device fully at rest
-                    again, which is enabled by default at 72 hours.</p>
+                    again, which is enabled by default at 18 hours. This can be configured at
+                    Settings > Security > Auto reboot.</p>
                 </section>
 
                 <section id="more-secure-fingerprint-unlock">


### PR DESCRIPTION
This PR changes the default timer mentioned in /features from 72 hours to 18 hours to reflect the new default. It also now mentions where someone needs to go to configure the timer.