### PR TITLE
Document "Require device to be charging" setting in Updater

### DIFF
--- a/static/usage.html
+++ b/static/usage.html
@@ -408,7 +408,10 @@
                     <p>The "Require battery above warning level" setting controls whether updates will
                     only be performed when the battery is above the level where the warning message is
                     shown. The standard value is at 15% capacity.</p>
-
+                    
+                    <p>The "Require device to be charging" setting controls whether updates will
+                    only be performed when the device is charging.</p>
+                    
                     <p>Enabling the opt-in "Automatic reboot" setting allows the updater to reboot the
                     device after an update once it has been idle for a long time. When this setting is
                     enabled, a device can take care of any number of updates completely automatically even


### PR DESCRIPTION
This PR briefly documents the "Require device to be charging" toggle in the Updater app's settings.