### PR TITLE
Add Contact Scopes section to Usage guide

### DIFF
--- a/static/features.html
+++ b/static/features.html
@@ -554,6 +554,9 @@
                     Contacts permission. By default, it acts as if the contacts list is empty and
                     users can grant different kinds of access to specific contacts or groups of
                     contacts.</p>
+
+                    <p>For more details, see the <a href="/usage#storage-access">usage guide section 
+                    on Contact Scopes</a>.</p>
                 </section>
 
                 <section id="broad-carrier-support">

--- a/static/usage.html
+++ b/static/usage.html
@@ -55,6 +55,7 @@
                             <li><a href="#storage-scopes">Storage Scopes</a></li>
                         </ul>
                     </li>
+                    <li><a href="#contact-scopes">Contact Scopes</a></li>
                     <li><a href="#accessibility">Accessibility</a></li>
                     <li><a href="#auditor">Auditor</a></li>
                     <li>
@@ -313,6 +314,41 @@
                     As a workaround, users can manually grant access to these files/directories via
                     SAF picker.</p>
                 </section>
+            </section>
+
+            <section id="contact-scopes">
+                <h2><a href="#contact-scopes">Contact Scopes</a></h2>
+
+                <p>For an introduction, read https://developer.android.com/guide/topics/providers/contacts-provider.</p>
+
+                <p>The Contact Scopes feature enables the user to grant an app read access to a subset of 
+                data in the OS ContactsProvider. Granting write access (insert(), update(), delete()) 
+                is not supported.</p>
+
+                <p>Read access can be granted to the following scopes:</p>
+
+                <ul>
+                    <li>Contact data (phone number or email). Access to each type of number and 
+                    email in a contact is granted separately. Access to contact name is 
+                    granted automatically.</li>
+
+                    <li>Single contact. Access is granted to all contact data, except photo, 
+                    originating account type and name, contact sync data.</li>
+
+                    <li>Contact group ("label"). Equivalent to granting access to all contacts 
+                    in the group. Any contact can be in any number of contact groups.</li>
+                </ul>
+
+                <p>Type and name of account that contact is stored in is fully hidden from the app.
+                Name of contact account is usually the same as email address of that account.</p>
+
+                <p>Access to SIM phonebook data is fully stubbed out: an empty and immutable content 
+                provider is exposed instead of the actual SIM phonebook. Implementations of legacy 
+                (ICC) and modern SIM stub phonebook providers are added to packages/services/Telephony.</p>
+
+                <p>The Contact Scopes feature is enabled per-app. When it's enabled, app's calls to contacts 
+                provider and to SIM phonebook providers are redirected, respectively, to ScopedContactsProvider
+                and to stub SIM phonebook providers.</p>
             </section>
 
             <section id="accessibility">


### PR DESCRIPTION
This PR adds a Contact Scopes section to /usage. It also links to it from the /features page.

The text is taken from https://github.com/muhomorr/platform_packages_providers_ContactsProvider/blob/13_05-16_ContactsProvider/ContactScopes.md and left almost entirely unchanged to maintain accuracy.