### PR TITLE
Clarify removal of sandboxed Google Play dependency for eSIM management

### DIFF
--- a/static/releases.html
+++ b/static/releases.html
@@ -750,7 +750,7 @@
 
                     <ul>
                         <li>isolate eSIM activation app from non-system apps to avoid it sharing data with sandboxed Google Play</li>
-                        <li>make eSIM activation toggle available without sandboxed Google Play installed</li>
+                        <li>make eSIM activation toggle available without sandboxed Google Play installed (this means that eSIM management no longer requires sandboxed Google Play)</li>
                         <li>make the eSIM activation app toggle persistent instead of it being disabled at boot</li>
                         <li>remove misleading message about device info being sent to Google message before eSIM download</li>
                         <li>hardened_malloc: use tag 0 for freed slots instead of reserving a tag to allow using 15 of 16 possible tag values for random tags (there are 3 dynamic exclusions of the random values for the previous tag along with the 2 current or previous adjacent tags)</li>


### PR DESCRIPTION
The current changelog wasn't fully clear for everyone. This should hopefully make it understood that eSIM activation/management no longer requires sandboxed Google Play on GrapheneOS.