### PR TITLE
fix redirect to eSIM support

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -271,10 +271,6 @@ http {
             return 301 /faq#default-connections;
         }
 
-        location = /usage#sandboxed-google-play-esim {
-            return 301 /usage#esim-support;
-        }
-
         # redirect away from the old SVG favicon location
         location = /mask-icon.svg {
             return 301 /favicon.svg;

--- a/static/js/redirect.js
+++ b/static/js/redirect.js
@@ -16,6 +16,7 @@ const redirects = new Map([
     ["/#upstream", "/faq#upstream"],
 
     ["/usage#default-connections", "/faq#default-connections"],
+    ["/usage#sandboxed-google-play-esim", "/usage#esim-support"],
     ["/usage#sandboxed-play-services", "/usage#sandboxed-google-play"],
     ["/usage#sandboxed-play-services-installation", "/usage#sandboxed-google-play-installation"],
     ["/usage#sandboxed-play-services-limitations", "/usage#sandboxed-google-play-limitations"],


### PR DESCRIPTION
URI fragment is not sent to the server so Nginx can't redirect to the section.