### PR TITLE
Improve eSIM support section

### DIFF
--- a/static/usage.html
+++ b/static/usage.html
@@ -1142,7 +1142,7 @@
             </section>
             <section id="esim-support">
                 <h3><a href="#esim-support">eSIM support</a></h3>
-                <p>By default GrapheneOS always has shipped with baseline support for eSIM,
+                <p>By default, GrapheneOS has always shipped with baseline support for eSIM,
                 where users can use any eSIMs installed previously on the device. However, in
                 order to manage and add eSIMs, proprietary Google functionality is needed. This
                 is fully disabled by default.</p>
@@ -1160,6 +1160,12 @@
                 "Checking network info..." stage despite having a stable Internet connection,
                 you may need to call the USSD code <code>*#*#4636#*#*</code> and then enable
                 DSDS in the menu that is presented.</p>
+
+                <p>If an eSIM locked with a PIN is used, it is recommended to leave the eSIM 
+                support toggle enabled even after activating the eSIM. This will allow you to
+                disable the eSIM on the lockscreen in case the PIN is forgotten. If the eSIM 
+                support toggle is disabled and the PIN is forgotten, there is no way to access 
+                the device unless the PUK is provided.</p>
             </section>
 
             <section id="android-auto">


### PR DESCRIPTION
This PR improves the eSIM documentation slightly, along with adding a paragraph advising users to leave it enabled if they use a PIN lock with their eSIM in case they forget the PIN, as they won't be able to get in without the PUK, which might be a pain to obtain.