### PR TITLE
Remove QuickSearchBox from repositories in source page

### DIFF
--- a/static/source.html
+++ b/static/source.html
@@ -136,7 +136,6 @@
                     <li><a href="https://github.com/GrapheneOS/platform_packages_apps_Launcher3">platform_packages_apps_Launcher3</a></li>
                     <li><a href="https://github.com/GrapheneOS/platform_packages_apps_Messaging">platform_packages_apps_Messaging</a></li>
                     <li><a href="https://github.com/GrapheneOS/platform_packages_apps_Nfc">platform_packages_apps_Nfc</a></li>
-                    <li><a href="https://github.com/GrapheneOS/platform_packages_apps_QuickSearchBox">platform_packages_apps_QuickSearchBox</a></li>
                     <li><a href="https://github.com/GrapheneOS/platform_packages_apps_Settings">platform_packages_apps_Settings</a></li>
                     <li><a href="https://github.com/GrapheneOS/platform_packages_apps_ThemePicker">platform_packages_apps_ThemePicker</a></li>
                     <li><a href="https://github.com/GrapheneOS/platform_packages_apps_WallpaperPicker2">platform_packages_apps_WallpaperPicker2</a></li>


### PR DESCRIPTION
This PR removes QSB from the repositories listed in the source page, as it is no longer being used.