### PR TITLE
Add Bluesky in releases page and update section

### DIFF
--- a/static/releases.html
+++ b/static/releases.html
@@ -396,10 +396,12 @@
 
                 <p>The announcements are also posted from the <a
                 href="https://twitter.com/GrapheneOS">@GrapheneOS Twitter
-                account</a>, on the <a href="https://reddit.com/r/GrapheneOS">official
-                subreddit</a>, and in the official <a href="/contact#community">GrapheneOS chat
-                rooms</a> including the dedicated #releases:grapheneos.org room for release
-                announcements. Each of these links to the main discussion thread on our discussion
+                account</a>, the <a href="https://grapheneos.social/@GrapheneOS">@GrapheneOS 
+                Mastodon account</a>, the <a href="https://bsky.app/profile/grapheneos.org">
+                @grapheneos.org Bluesky account</a>, the <a href="https://reddit.com/r/GrapheneOS">
+                official subreddit</a>, and in the official <a href="/contact#community">GrapheneOS chat
+                rooms</a> including the dedicated releases room/channel on the respective chat platform 
+                (Matrix, Discord, Telegram). Each of these links to the main discussion thread on our discussion
                 forum.</p>
             </section>
 


### PR DESCRIPTION
This PR adds Bluesky in the list of social media platforms used for release announcements, along with changing the matrix-specific release room mention to a more generic mention of release channels/rooms on respect chat platforms.