### PR TITLE
Add needed apk build target for shipping components out of band

### DIFF
--- a/static/build.html
+++ b/static/build.html
@@ -944,7 +944,7 @@ git checkout <var>VERSION</var></pre>
 
                     <p>Build the components:</p>
 
-                    <pre>chrt -b 0 ninja -C out/Default/ trichrome_webview_64_32_apk trichrome_chrome_64_32_apk trichrome_library_64_32_apk</pre>
+                    <pre>chrt -b 0 ninja -C out/Default/ trichrome_webview_64_32_apk trichrome_chrome_64_32_apk trichrome_library_64_32_apk vanadium_config_apk</pre>
 
                     <p>Sign the apks:</p>
 


### PR DESCRIPTION
This is necessary for a future Vanadium release adding support to update components out of band and default feature flags via a config app. Currently, only the content filtering component, named "Subresource Filter Rules", is shipped via this app.