### PR TITLE
Remove content filtering from upcoming features

### DIFF
--- a/static/usage.html
+++ b/static/usage.html
@@ -550,8 +550,8 @@
 
                 <p>Vanadium was previously primarily focused on security hardening but we plan on
                 adding assorted privacy and usability features. In the near future, we plan to add
-                support for always incognito mode, content filtering (ad blocking, etc.), improved
-                state partitioning, backup/restore and many other features.</p>
+                support for always incognito mode, improved state partitioning, backup/restore
+                and many other features.</p>
 
                 <p>Chromium-based browsers like Vanadium provide the strongest sandbox
                 implementation, leagues ahead of the alternatives. It is much harder to escape


### PR DESCRIPTION
This PR removes content filtering from the paragraph that mentions upcoming features for Vanadium, as this has now been implemented.