### PR TITLE
remove link to Reddit from the footer

### DIFF
--- a/templates/footer.html
+++ b/templates/footer.html
@@ -10,7 +10,6 @@
         <li><a href="https://grapheneos.social/@GrapheneOS">Mastodon</a></li>
         <li><a href="https://bsky.app/profile/grapheneos.org">Bluesky</a></li>
         <li><a href="https://github.com/GrapheneOS">GitHub</a></li>
-        <li><a href="https://reddit.com/r/GrapheneOS">Reddit</a></li>
         <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
     </ul>
 </footer>


### PR DESCRIPTION
GrapheneOS has moved away from Reddit to the combination of self-hosted discussion forum and chat rooms that are bridged across Discord, Telegram and Matrix.