### PR TITLE
List new repositories

### DIFF
--- a/static/source.html
+++ b/static/source.html
@@ -162,6 +162,7 @@
                     <li><a href="https://github.com/GrapheneOS/platform_system_logging">platform_system_logging</a></li>
                     <li><a href="https://github.com/GrapheneOS/platform_system_librustutils">platform_system_librustutils</a></li>
                     <li><a href="https://github.com/GrapheneOS/platform_system_sepolicy">platform_system_sepolicy</a></li>
+                    <li><a href="https://github.com/GrapheneOS/platform_hardware_interfaces">platform_hardware_interfaces</a></li>
                 </ul>
 
                 <p>GrapheneOS forks of AOSP kernel prebuilt repositories with the builds replaced with the GrapheneOS kernels built from the source repositories listed in the next section:</p>
@@ -209,6 +210,7 @@
                     <li><a href="https://github.com/GrapheneOS/kernel_build-gs">kernel_build-gs</a>: Kernel build system for the Pixel 6, Pixel 6 Pro, Pixel 6a, Pixel 7, Pixel 7 Pro, Pixel 7a, Pixel Tablet and Pixel Fold.</li>
                     <li><a href="https://github.com/GrapheneOS/kernel_gs">kernel_gs</a>: Kernel sources for the Pixel 6, Pixel 6 Pro, Pixel 6a, Pixel 7, Pixel 7 Pro, Pixel 7a, Pixel Tablet and Pixel Fold. These sources are only used to build device-specific modules. The Generic Kernel Image is built from the common kernel.</li>
                     <li><a href="https://github.com/GrapheneOS/kernel_google-modules_gpu-gs">kernel_google-modules_gpu-gs</a>: Kernel GPU driver for the Pixel 6, Pixel 6 Pro, Pixel 6a, Pixel 7, Pixel 7 Pro, Pixel 7a, Pixel Tablet and Pixel Fold.</li>
+                    <li><a href="https://github.com/GrapheneOS/kernel_google-modules_soc_gs">kernel_google-modules_gpu-gs</a>: Kernel SoC driver for the Pixel 6, Pixel 6 Pro, Pixel 6a, Pixel 7, Pixel 7 Pro, Pixel 7a, Pixel Tablet and Pixel Fold.</li>
                     <li><a href="https://github.com/GrapheneOS/kernel_google-modules_power_reset-gs">kernel_google-modules_power_reset-gs</a>: Kernel reset driver for the Pixel 6, Pixel 6 Pro, Pixel 6a, Pixel 7, Pixel 7 Pro, Pixel 7a, Pixel Tablet and Pixel Fold.</li>
                     <li><a href="https://github.com/GrapheneOS/kernel_google-modules_wlan_bcmdhd_bcm4389">kernel_google-modules_wlan_bcmdhd_bcm4389</a>: Kernel Wi-Fi/Bluetooth driver for the Pixel 6, Pixel 6 Pro, Pixel 6a, Pixel 7, Pixel 7 Pro and Pixel Fold.</li>
                     <li><a href="https://github.com/GrapheneOS/kernel_manifest-shusky">kernel_manifest-shusky</a>: Kernel manifest for the Pixel 8 and Pixel 8 Pro.</li>


### PR DESCRIPTION
List the following repositories in the source page:

1. https://github.com/GrapheneOS/platform_hardware_interfaces
2. https://github.com/GrapheneOS/kernel_google-modules_soc_gs

This should be probably be merged after https://github.com/GrapheneOS/platform_frameworks_base/pull/485 and related pull requests are merged.