### PR TITLE
Add FAQ entry regarding locking the bootloader

### DIFF
--- a/static/faq.html
+++ b/static/faq.html
@@ -104,6 +104,7 @@
                             <li><a href="#file-transfer">How do I transfer files to another device?</a></li>
                         </ul>
                     </li>
+                    <li><a href="#bootloader-locking-setup">Why am I seeing a message about my bootloader not being locked when setting up the device?</a></li>
                     <li><a href="#google-services">Will GrapheneOS include support for Google services?</a></li>
                     <li><a href="#features">What features does GrapheneOS implement?</a></li>
                     <li><a href="#anti-theft">Does GrapheneOS provide Factory Reset Protection?</a></li>
@@ -1572,6 +1573,32 @@
                     the files to yourself via an end-to-end encrypted messaging app like Element (Matrix).</p>
                 </article>
             </section>
+
+            <article id="bootloader-locking-setup">
+                <h2><a href="#bootloader-locking-setup">Why am I seeing a message about my bootloader not being locked when setting up the device?</a></h2>
+
+                <p>If you are seeing this warning when setting up your device after installing GrapheneOS, 
+                it means that you have not followed all of the installation steps. This can be remediated 
+                by finishing the installation process and locking the device's bootloader.</p>
+
+                <p>To do this, follow these steps:</p>
+
+               <li>
+                        <ol>
+                            <li>Navigate to the bootloader locking section of the <a href="https://grapheneos.org/install/web">web install 
+                            (recommended)</a> or <a href="https://grapheneos.org/install/cli">CLI install</a> guide.</li>
+                            <li>Press "Next" on the setup screen.</li>
+                            <li>On the confirmation prompt, tap on "Yes, reboot to bootloader".</li>
+                            <li>Connect your GrapheneOS device to the device where you have the install page open.</li>
+                            <li>Follow the steps on the respective install page to lock the bootloader.</li>
+                            <li>Once locked, you can start setting up your GrapheneOS device.</li>
+                        </ol>
+               </li>
+
+                <p>It is important to note that this is something that should be done as soon as possible, 
+                rather than after settup, as locking the bootloader wipes all user data on the device, 
+                along with making the device insecure.</p>
+                </article>
 
             <article id="google-services">
                 <h2><a href="#google-services">Will GrapheneOS include support for Google services?</a></h2>

--- a/static/faq.html
+++ b/static/faq.html
@@ -1477,7 +1477,6 @@
 
                     <p>To do this, follow these steps:</p>
 
-                    <li>
                         <ol>
                             <li>Navigate to the bootloader locking section of the <a href="https://grapheneos.org/install/web">web install 
                             (recommended)</a> or <a href="https://grapheneos.org/install/cli">CLI install</a> guide.</li>
@@ -1487,7 +1486,6 @@
                             <li>Follow the steps on the respective install page to lock the bootloader.</li>
                             <li>Once locked, you can start setting up your GrapheneOS device.</li>
                         </ol>
-                   </li>
 
                     <p>It is important to note that this is something that should be done before placing any data onto the device, 
                     as until this step is completed, the device is considered to be insecure. Please note that locking the bootloader 

--- a/static/faq.html
+++ b/static/faq.html
@@ -1466,6 +1466,33 @@
                     is problematic and a HardMAC implementation with most complexity in the isolated
                     firmware could be better than the status quo. An isolated driver would be ideal.</p>
                 </article>
+
+                <article id="bootloader-locking-setup">
+                <h2><a href="#bootloader-locking-setup">Why am I seeing a message about my bootloader not being locked when setting up the device?</a></h2>
+
+                <p>If you are seeing this warning when setting up your device after installing GrapheneOS, 
+                it means that you have not followed all of the installation steps. This can be remediated 
+                by finishing the installation process and locking the device's bootloader.</p>
+
+                <p>To do this, follow these steps:</p>
+
+               <li>
+                        <ol>
+                            <li>Navigate to the bootloader locking section of the <a href="https://grapheneos.org/install/web">web install 
+                            (recommended)</a> or <a href="https://grapheneos.org/install/cli">CLI install</a> guide.</li>
+                            <li>Press "Next" on the setup screen.</li>
+                            <li>On the confirmation prompt, tap on "Yes, reboot to bootloader".</li>
+                            <li>Connect your GrapheneOS device to the device where you have the install page open.</li>
+                            <li>Follow the steps on the respective install page to lock the bootloader.</li>
+                            <li>Once locked, you can start setting up your GrapheneOS device.</li>
+                        </ol>
+               </li>
+
+                <p>It is important to note that this is something that should be done before placing any data onto the device, 
+                as until this step is completed, the device is considered to be insecure. Please note that locking the bootloader 
+                wipes all user data on the device. GrapheneOS does not give any support whatsoever to users running with 
+                an unlocked bootloader, as this is considered to be an incomplete installation.</p>
+                </article>
             </section>
 
             <section id="day-to-day-use">
@@ -1573,33 +1600,6 @@
                     the files to yourself via an end-to-end encrypted messaging app like Element (Matrix).</p>
                 </article>
             </section>
-
-            <article id="bootloader-locking-setup">
-                <h2><a href="#bootloader-locking-setup">Why am I seeing a message about my bootloader not being locked when setting up the device?</a></h2>
-
-                <p>If you are seeing this warning when setting up your device after installing GrapheneOS, 
-                it means that you have not followed all of the installation steps. This can be remediated 
-                by finishing the installation process and locking the device's bootloader.</p>
-
-                <p>To do this, follow these steps:</p>
-
-               <li>
-                        <ol>
-                            <li>Navigate to the bootloader locking section of the <a href="https://grapheneos.org/install/web">web install 
-                            (recommended)</a> or <a href="https://grapheneos.org/install/cli">CLI install</a> guide.</li>
-                            <li>Press "Next" on the setup screen.</li>
-                            <li>On the confirmation prompt, tap on "Yes, reboot to bootloader".</li>
-                            <li>Connect your GrapheneOS device to the device where you have the install page open.</li>
-                            <li>Follow the steps on the respective install page to lock the bootloader.</li>
-                            <li>Once locked, you can start setting up your GrapheneOS device.</li>
-                        </ol>
-               </li>
-
-                <p>It is important to note that this is something that should be done before placing any data onto the device, 
-                as until this step is completed, the device is considered to be insecure. Please note that locking the bootloader 
-                wipes all user data on the device. GrapheneOS does not give any support whatsoever to users running with 
-                an unlocked bootloader, as this is considered to be an incomplete installation.</p>
-                </article>
 
             <article id="google-services">
                 <h2><a href="#google-services">Will GrapheneOS include support for Google services?</a></h2>

--- a/static/faq.html
+++ b/static/faq.html
@@ -1479,12 +1479,13 @@
 
                         <ol>
                             <li>Navigate to the bootloader locking section of the <a href="https://grapheneos.org/install/web">web install 
-                            (recommended)</a> or <a href="https://grapheneos.org/install/cli">CLI install</a> guide.</li>
-                            <li>Press "Next" on the setup screen.</li>
-                            <li>On the confirmation prompt, tap on "Yes, reboot to bootloader".</li>
+                            (recommended)</a> or <a href="https://grapheneos.org/install/cli">CLI install</a> guide on the device you'll be
+                            using the lock the bootloader.</li>
+                            <li>If you are at the welcome screen on your GrapheneOS device, tap "Next".</li>
+                            <li>On the resulting screen, tap "Reboot to bootloader".</li>
                             <li>Connect your GrapheneOS device to the device where you have the install page open.</li>
-                            <li>Follow the steps on the respective install page to lock the bootloader.</li>
-                            <li>Once locked, you can start setting up your GrapheneOS device.</li>
+                            <li>Follow the steps on the install page to lock the bootloader.</li>
+                            <li>Once locked, you can start setting up your GrapheneOS device, and the warning should no longer be present.</li>
                         </ol>
 
                     <p>It is important to note that this is something that should be done before placing any data onto the device, 

--- a/static/faq.html
+++ b/static/faq.html
@@ -1595,9 +1595,10 @@
                         </ol>
                </li>
 
-                <p>It is important to note that this is something that should be done as soon as possible, 
-                rather than after settup, as locking the bootloader wipes all user data on the device, 
-                along with making the device insecure.</p>
+                <p>It is important to note that this is something that should be done before placing any data onto the device, 
+                as until this step is completed, the device is considered to be insecure. Please note that locking the bootloader 
+                wipes all user data on the device. GrapheneOS does not give any support whatsoever to users running with 
+                an unlocked bootloader, as this is considered to be an incomplete installation.</p>
                 </article>
 
             <article id="google-services">

--- a/static/faq.html
+++ b/static/faq.html
@@ -1468,15 +1468,15 @@
                 </article>
 
                 <article id="bootloader-locking-setup">
-                <h2><a href="#bootloader-locking-setup">Why am I seeing a message about my bootloader not being locked when setting up the device?</a></h2>
+                    <h2><a href="#bootloader-locking-setup">Why am I seeing a message about my bootloader not being locked when setting up the device?</a></h2>
 
-                <p>If you are seeing this warning when setting up your device after installing GrapheneOS, 
-                it means that you have not followed all of the installation steps. This can be remediated 
-                by finishing the installation process and locking the device's bootloader.</p>
+                    <p>If you are seeing this warning when setting up your device after installing GrapheneOS, 
+                    it means that you have not followed all of the installation steps. This can be remediated 
+                    by finishing the installation process and locking the device's bootloader.</p>
 
-                <p>To do this, follow these steps:</p>
+                    <p>To do this, follow these steps:</p>
 
-               <li>
+                    <li>
                         <ol>
                             <li>Navigate to the bootloader locking section of the <a href="https://grapheneos.org/install/web">web install 
                             (recommended)</a> or <a href="https://grapheneos.org/install/cli">CLI install</a> guide.</li>
@@ -1486,12 +1486,12 @@
                             <li>Follow the steps on the respective install page to lock the bootloader.</li>
                             <li>Once locked, you can start setting up your GrapheneOS device.</li>
                         </ol>
-               </li>
+                   </li>
 
-                <p>It is important to note that this is something that should be done before placing any data onto the device, 
-                as until this step is completed, the device is considered to be insecure. Please note that locking the bootloader 
-                wipes all user data on the device. GrapheneOS does not give any support whatsoever to users running with 
-                an unlocked bootloader, as this is considered to be an incomplete installation.</p>
+                    <p>It is important to note that this is something that should be done before placing any data onto the device, 
+                    as until this step is completed, the device is considered to be insecure. Please note that locking the bootloader 
+                    wipes all user data on the device. GrapheneOS does not give any support whatsoever to users running with 
+                    an unlocked bootloader, as this is considered to be an incomplete installation.</p>
                 </article>
             </section>
 

--- a/static/faq.html
+++ b/static/faq.html
@@ -92,6 +92,7 @@
                             <li><a href="#ad-blocking">How can I set up system-wide ad-blocking?</a></li>
                             <li><a href="#ad-blocking-apps">Are ad-blocking apps supported?</a></li>
                             <li><a href="#baseband-isolation">Is the baseband isolated?</a></li>
+                            <li><a href="#bootloader-locking-setup">Why am I seeing a message about my bootloader not being locked when setting up the device?</a></li>
                         </ul>
                     </li>
                     <li>
@@ -104,7 +105,6 @@
                             <li><a href="#file-transfer">How do I transfer files to another device?</a></li>
                         </ul>
                     </li>
-                    <li><a href="#bootloader-locking-setup">Why am I seeing a message about my bootloader not being locked when setting up the device?</a></li>
                     <li><a href="#google-services">Will GrapheneOS include support for Google services?</a></li>
                     <li><a href="#features">What features does GrapheneOS implement?</a></li>
                     <li><a href="#anti-theft">Does GrapheneOS provide Factory Reset Protection?</a></li>

--- a/static/faq.html
+++ b/static/faq.html
@@ -1480,7 +1480,7 @@
                         <ol>
                             <li>Navigate to the bootloader locking section of the <a href="https://grapheneos.org/install/web">web install 
                             (recommended)</a> or <a href="https://grapheneos.org/install/cli">CLI install</a> guide on the device you'll be
-                            using the lock the bootloader.</li>
+                            using to lock the bootloader.</li>
                             <li>If you are at the welcome screen on your GrapheneOS device, tap "Next".</li>
                             <li>On the resulting screen, tap "Reboot to bootloader".</li>
                             <li>Connect your GrapheneOS device to the device where you have the install page open.</li>
@@ -1490,7 +1490,7 @@
 
                     <p>It is important to note that this is something that should be done before placing any data onto the device, 
                     as until this step is completed, the device is considered to be insecure. Please note that locking the bootloader 
-                    wipes all user data on the device. GrapheneOS does not give any support whatsoever to users running with 
+                    wipes all user data on the device. GrapheneOS doesn't provide any support to users running GrapheneOS with 
                     an unlocked bootloader, as this is considered to be an incomplete installation.</p>
                 </article>
             </section>

--- a/static/faq.html
+++ b/static/faq.html
@@ -1470,9 +1470,10 @@
                 <article id="bootloader-locking-setup">
                     <h2><a href="#bootloader-locking-setup">Why am I seeing a message about my bootloader not being locked when setting up the device?</a></h2>
 
-                    <p>If you are seeing this warning when setting up your device after installing GrapheneOS, 
-                    it means that you have not followed all of the installation steps. This can be remediated 
-                    by finishing the installation process and locking the device's bootloader.</p>
+                    <p>If you are seeing this warning when setting up your device after GrapheneOS has been 
+                    installed, it means that not all of the installation steps have not been completed. 
+                    This can be remediated by finishing the installation process and locking the device's 
+                    bootloader.</p>
 
                     <p>To do this, follow these steps:</p>
 

--- a/static/faq.html
+++ b/static/faq.html
@@ -1471,7 +1471,7 @@
                     <h2><a href="#bootloader-locking-setup">Why am I seeing a message about my bootloader not being locked when setting up the device?</a></h2>
 
                     <p>If you are seeing this warning when setting up your device after GrapheneOS has been 
-                    installed, it means that not all of the installation steps have not been completed. 
+                    installed, it means that not all of the installation steps have been completed. 
                     This can be remediated by finishing the installation process and locking the device's 
                     bootloader.</p>
 


### PR DESCRIPTION
This PR adds an FAQ entry regarding the lock bootloader steps and guides the user who is seeing a message on their setup wizard that it is unlocked to lock it.

This section will be linked from within the setup wizard via a redirect such as grapheneos.org/UBL.