### PR TITLE
Clarify that footer formatting issue is upstream

### DIFF
--- a/static/releases.html
+++ b/static/releases.html
@@ -741,7 +741,7 @@
                         <li>allowlist using device controls quick tile when unlocked since it already has a toggle for controlling availability so our new default requirement of the device being unlocked needs to be overridden for it</li>
                         <li>revert disabling hardened_malloc for Broadcom Bluetooth HAL (does not appear to be a memory corruption bug found by GrapheneOS but rather the stock OS is using an older Bluetooth module without the issue)</li>
                         <li>revert allowing users to disable Bluetooth for Bluetooth system app (does not appear to be a memory corruption bug found by GrapheneOS but rather the stock OS is using an older Bluetooth module without the issue)</li>
-                        <li>Settings: fix footer formatting issue for App pinning screen</li>
+                        <li>Settings: fix upstream footer formatting issue for App pinning screen</li>
                         <li>GmsCompatConfig: update to <a href="https://github.com/GrapheneOS/platform_packages_apps_GmsCompat/releases/tag/config-99">version 99</a></li>
                     </ul>
                 </article>


### PR DESCRIPTION
The issue was confirmed to be upstream, with the commit introducing the bug being this:

https://github.com/GrapheneOS/platform_packages_apps_Settings/commit/20976c3a53802a8b78cab20e49154244ddaf9ddd