### PR TITLE
add redirect from /UBL to FAQ section

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -308,6 +308,10 @@ http {
             return 301 https://discuss.grapheneos.org/d/11-grapheneos-code-of-conduct;
         }
 
+        location = /UBL {
+            return 301 /faq#bootloader-locking-setup;
+        }
+
         location = /404 {
             internal;
             include snippets/security-headers.conf;


### PR DESCRIPTION
This should ship alongside https://github.com/GrapheneOS/grapheneos.org/pull/887

grapheneos.org/UBL will appear in the Setup Wizard as a short link to guide people to the relevant FAQ section to assist them in locking their bootloader.