### PR TITLE
Redirect from /ubl to new bootloader locking FAQ section

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -312,6 +312,10 @@ http {
             return 301 /faq#bootloader-locking-setup;
         }
 
+        location = /ubl {
+            return 301 /faq#bootloader-locking-setup;
+        }
+
         location = /404 {
             internal;
             include snippets/security-headers.conf;


### PR DESCRIPTION
This also adds lowercase `UBL` (ubl) as a redirect to the new section regarding bootloader locking.