### PR TITLE
Document OEM unlocking checkbox in install guides

### DIFF
--- a/static/install/cli.html
+++ b/static/install/cli.html
@@ -536,11 +536,14 @@ curl -O https://releases.grapheneos.org/<var>DEVICE_NAME</var>-factory-<var>VERS
                 <section id="disabling-oem-unlocking">
                     <h3><a href="#disabling-oem-unlocking">Disabling OEM unlocking</a></h3>
 
-                    <p>OEM unlocking can be disabled again in the developer settings menu within the
-                    operating system after booting it up again.</p>
-
-                    <p>After disabling OEM unlocking, we recommend disabling developer options as
-                    a whole for a device that's not being used for app or OS development.</p>
+                    <p>During first setup, the final screen will contain a toggle regarding OEM unlocking
+                    which is checked by default. This will disable OEM unlocking, which is recommended.</p>
+    
+                    <p>If you need to enable or disable OEM unlocking in the future, it can be done in the 
+                    developer settings menu within the operating system.</p>
+    
+                    <p>After manually disabling OEM unlocking via developer options, we recommend disabling 
+                    them as a whole for a device that's not being used for app or OS development.</p>
                 </section>
 
                 <section id="verifying-installation">

--- a/static/install/web.html
+++ b/static/install/web.html
@@ -343,11 +343,14 @@
                 <section id="disabling-oem-unlocking">
                     <h3><a href="#disabling-oem-unlocking">Disabling OEM unlocking</a></h3>
 
-                    <p>OEM unlocking can be disabled again in the developer settings menu within the
-                    operating system after booting it up again.</p>
+                    <p>During first setup, the final screen will contain a toggle regarding OEM unlocking
+                    which is checked by default. This will disable OEM unlocking, which is recommended.</p>
 
-                    <p>After disabling OEM unlocking, we recommend disabling developer options as
-                    a whole for a device that's not being used for app or OS development.</p>
+                    <p>If you need to enable or disable OEM unlocking in the future, it can be done in the 
+                    developer settings menu within the operating system.</p>
+
+                    <p>After manually disabling OEM unlocking via developer options, we recommend disabling 
+                    them as a whole for a device that's not being used for app or OS development.</p>
                 </section>
 
                 <section id="verifying-installation">


### PR DESCRIPTION
This PR adjusts the OEM unlocking section in both of the install guides to document that checkbox at the end of the setup wizard that disables OEM unlocking, along with providing instructions on how to enable/disable OEM unlocking should it be done in the future.

[this should be merged after an OS release is made that includes the OEM unlocking chebcox change]