### PR TITLE
Add link to community chat/forum in bootloader locking FAQ section

### DIFF
--- a/static/faq.html
+++ b/static/faq.html
@@ -1495,6 +1495,12 @@
                     user data on the device. GrapheneOS doesn't provide any support to users running
                     GrapheneOS with an unlocked bootloader, as this is considered to be an
                     incomplete installation.</p>
+
+                    <p>If you are having trouble with completing this step and locking the device's 
+                    bootloader, consider reaching out to the 
+                    <a href="https://grapheneos.org/contact#community">GrapheneOS community</a> 
+                    for assistance. The official chat rooms are a better choice for troubleshooting 
+                    issues in real time, however we also have our forum where our community can help.</p>
                 </article>
             </section>
 


### PR DESCRIPTION
This PR adds a paragraph to the new FAQ section regarding bootloader locking that tells users to reach out to the community for help if they are having trouble with locking the bootloader.

This makes sense as it's not expected that many people will hit the flow that leads to that FAQ section (as it means they've skipped a crucial step of the install procedure). As such, it stands to reason that the users hitting the bootloader locking warning in setup wizard might not be tech-savvy and could therefore use help from our community to help them get it done.