### PR TITLE
Move OEM unlocking section further down

### DIFF
--- a/static/install/cli.html
+++ b/static/install/cli.html
@@ -87,7 +87,6 @@
                         <a href="#post-installation">Post-installation</a>
                         <ul>
                             <li><a href="#booting">Booting</a></li>
-                            <li><a href="#disabling-oem-unlocking">Disabling OEM unlocking</a></li>
                             <li>
                                 <a href="#verifying-installation">Verifying installation</a>
                                 <ul>
@@ -95,6 +94,7 @@
                                     <li><a href="#hardware-based-attestation">Hardware-based attestation</a></li>
                                 </ul>
                             </li>
+                            <li><a href="#disabling-oem-unlocking">Disabling OEM unlocking</a></li>
                             <li><a href="#further-information">Further information</a></li>
                             <li><a href="#replacing-grapheneos-with-the-stock-os">Replacing GrapheneOS with the stock OS</a></li>
                         </ul>
@@ -533,19 +533,6 @@ curl -O https://releases.grapheneos.org/<var>DEVICE_NAME</var>-factory-<var>VERS
                     interface will boot the OS.</p>
                 </section>
 
-                <section id="disabling-oem-unlocking">
-                    <h3><a href="#disabling-oem-unlocking">Disabling OEM unlocking</a></h3>
-
-                    <p>During first setup, the final screen will contain a toggle regarding OEM unlocking
-                    which is checked by default. This will disable OEM unlocking, which is recommended.</p>
-    
-                    <p>If you need to enable or disable OEM unlocking in the future, it can be done in the 
-                    developer settings menu within the operating system.</p>
-    
-                    <p>After manually disabling OEM unlocking via developer options, we recommend disabling 
-                    them as a whole for a device that's not being used for app or OS development.</p>
-                </section>
-
                 <section id="verifying-installation">
                     <h3><a href="#verifying-installation">Verifying installation</a></h3>
 
@@ -631,6 +618,19 @@ curl -O https://releases.grapheneos.org/<var>DEVICE_NAME</var>-factory-<var>VERS
                         future with optional support for the hardware serial number attestation
                         feature.</p>
                     </section>
+                </section>
+
+                <section id="disabling-oem-unlocking">
+                    <h3><a href="#disabling-oem-unlocking">Disabling OEM unlocking</a></h3>
+
+                    <p>During first setup, the final screen will contain a toggle regarding OEM unlocking
+                    which is checked by default. This will disable OEM unlocking, which is recommended.</p>
+    
+                    <p>If you need to enable or disable OEM unlocking in the future, it can be done in the 
+                    developer settings menu within the operating system.</p>
+    
+                    <p>After manually disabling OEM unlocking via developer options, we recommend disabling 
+                    them as a whole for a device that's not being used for app or OS development.</p>
                 </section>
 
                 <section id="further-information">

--- a/static/install/web.html
+++ b/static/install/web.html
@@ -65,7 +65,6 @@
                         <a href="#post-installation">Post-installation</a>
                         <ul>
                             <li><a href="#booting">Booting</a></li>
-                            <li><a href="#disabling-oem-unlocking">Disabling OEM unlocking</a></li>
                             <li>
                                 <a href="#verifying-installation">Verifying installation</a>
                                 <ul>
@@ -73,6 +72,7 @@
                                     <li><a href="#hardware-based-attestation">Hardware-based attestation</a></li>
                                 </ul>
                             </li>
+                            <li><a href="#disabling-oem-unlocking">Disabling OEM unlocking</a></li>
                             <li><a href="#further-information">Further information</a></li>
                             <li><a href="#replacing-grapheneos-with-the-stock-os">Replacing GrapheneOS with the stock OS</a></li>
                         </ul>
@@ -340,19 +340,6 @@
                     interface will boot the OS.</p>
                 </section>
 
-                <section id="disabling-oem-unlocking">
-                    <h3><a href="#disabling-oem-unlocking">Disabling OEM unlocking</a></h3>
-
-                    <p>During first setup, the final screen will contain a toggle regarding OEM unlocking
-                    which is checked by default. This will disable OEM unlocking, which is recommended.</p>
-
-                    <p>If you need to enable or disable OEM unlocking in the future, it can be done in the 
-                    developer settings menu within the operating system.</p>
-
-                    <p>After manually disabling OEM unlocking via developer options, we recommend disabling 
-                    them as a whole for a device that's not being used for app or OS development.</p>
-                </section>
-
                 <section id="verifying-installation">
                     <h3><a href="#verifying-installation">Verifying installation</a></h3>
 
@@ -438,6 +425,19 @@
                         future with optional support for the hardware serial number attestation
                         feature.</p>
                     </section>
+                </section>
+
+                <section id="disabling-oem-unlocking">
+                    <h3><a href="#disabling-oem-unlocking">Disabling OEM unlocking</a></h3>
+
+                    <p>During first setup, the final screen will contain a toggle regarding OEM unlocking
+                    which is checked by default. This will disable OEM unlocking, which is recommended.</p>
+
+                    <p>If you need to enable or disable OEM unlocking in the future, it can be done in the 
+                    developer settings menu within the operating system.</p>
+
+                    <p>After manually disabling OEM unlocking via developer options, we recommend disabling 
+                    them as a whole for a device that's not being used for app or OS development.</p>
                 </section>
 
                 <section id="further-information">


### PR DESCRIPTION
As OEM unlocking is handled as part of the setup process, we should deprioritize it in the post-install steps as it's handled by default instead of the user needing to go into developer options.