### PR TITLE
Rework auto-reboot documentation

### DIFF
--- a/static/features.html
+++ b/static/features.html
@@ -757,7 +757,7 @@
                     <p>GrapheneOS provides an auto-reboot feature which reboots locked devices after 
                     a set period of time to put data at rest. A countdown timer is started each time 
                     the device is locked, and the device will reboot if a successful unlock doesn't 
-                    occur before the timer reaches zero. Unlocking any profile resets the timer, not
+                    occur before the timer reaches zero. Unlocking any profile cancels the timer, not
                     just the Owner profile.</p>
 
                     <p>The timer is set to 18 hours by default, but can be set to values between 10 

--- a/static/features.html
+++ b/static/features.html
@@ -766,12 +766,6 @@
                     <p>This feature doesn't apply when the device is in "Before First Unlock" 
                     state, meaning that it will not lead to the device continuously rebooting, 
                     as data is already at rest.</p>
-
-                    <p>Note that for the timer to start, the screen has to be locked, rather than the 
-                    screen merely being turned off. For example, using the standard Android 
-                    <a href="https://support.google.com/android/answer/9455138?hl=en">app pinning feature</a> and 
-                    turning the screen off without unpinning the app first won't result in the timer being 
-                    started, as the screen was never locked in that case.</p>
                 </section>
 
                 <section id="more-secure-fingerprint-unlock">

--- a/static/features.html
+++ b/static/features.html
@@ -754,10 +754,24 @@
                 <section id="auto-reboot">
                     <h3><a href="#auto-reboot">Auto reboot</a></h3>
 
-                    <p>Option to enable automatically rebooting the device when no profile has
-                    been unlocked for the configured period to put the device fully at rest
-                    again, which is enabled by default at 18 hours. This can be configured at
-                    Settings > Security > Auto reboot.</p>
+                    <p>GrapheneOS provides an auto-reboot feature which reboots locked devices after 
+                    a set period of time to put data at rest. A countdown timer is started each time 
+                    the device is locked, and the device will reboot if a successful unlock doesn't 
+                    occur before the timer reaches zero. Unlocking any profile resets the timer, not
+                    just the Owner profile.</p>
+
+                    <p>The timer is set to 18 hours by default, but can be set to values between 10 
+                    minutes and 72 hours, or turned off.</p>
+
+                    <p>This feature doesn't apply when the device is in "Before First Unlock" 
+                    state, meaning that it will not lead to the device continuously rebooting, 
+                    as data is already at rest.</p>
+
+                    <p>Note that for the timer to start, the screen has to be locked, rather than the 
+                    screen merely being turned off. For example, using the standard Android 
+                    <a href="https://support.google.com/android/answer/9455138?hl=en">app pinning feature</a> and 
+                    turning the screen off without unpinning the app first won't result in the timer being 
+                    started, as the screen was never locked in that case.</p>
                 </section>
 
                 <section id="more-secure-fingerprint-unlock">


### PR DESCRIPTION
This PR adds more details to the Features entry for the auto-reboot feature to make it more complete and elaborate on a few things.

Specifically:

1. It explains the range of time that the setting can be set to, and that it can be disabled.
2. It explains that it doesn't apply to devices in BFU state
3. It further elaborates and draws attention to edge cases that people think the feature applies to, but doesn't (such as when an app is pinned and the screen is turned off)
4. It explains that any profile being successfully unlocked gets rid of the timer, not just the owner profile.