### PR TITLE
Update password length to 128 in documentation

### DIFF
--- a/static/features.html
+++ b/static/features.html
@@ -741,7 +741,7 @@
                 <section id="supports-longer-passwords">
                     <h3><a href="#supports-longer-passwords">Supports longer passwords</a></h3>
 
-                    <p>GrapheneOS supports setting longer passwords by default: 64 characters
+                    <p>GrapheneOS supports setting longer passwords by default: 128 characters
                     instead of 16 characters. This avoids the need to use a device manager to
                     enable this functionality.</p>
 


### PR DESCRIPTION
This PR updates password length from previous adjusted value of 64 to 128 in the features page.