### PR TITLE
Add footer link to NodePing status page

### DIFF
--- a/templates/footer.html
+++ b/templates/footer.html
@@ -12,5 +12,6 @@
         <li><a href="https://github.com/GrapheneOS">GitHub</a></li>
         <li><a href="https://reddit.com/r/GrapheneOS">Reddit</a></li>
         <li><a href="https://www.linkedin.com/company/grapheneos/">LinkedIn</a></li>
+        <li><a href="https://nodeping.com/reports/statusevents/3FL97F6RRQHJIOWL">Status</a></li>
     </ul>
 </footer>


### PR DESCRIPTION
### Description
As the PR title reads. Adds the NodePing status page as a link in the footer.

### Related Issue
#860 