### PR TITLE
Add section in servers page for GrapheneOS production server status link

### DIFF
--- a/static/articles/grapheneos-servers.html
+++ b/static/articles/grapheneos-servers.html
@@ -53,6 +53,7 @@
                     <li><a href="#ns1.staging.grapheneos.org">Staging GrapheneOS DNS server</a></li>
                     <li><a href="#attestation.app">Attestation website and service</a></li>
                     <li><a href="#staging.attestation.app">Staging attestation website and service</a></li>
+                    <li><a href="#servers-status">GrapheneOS Production Server Status</a></li>
                 </ul>
             </nav>
 
@@ -724,6 +725,14 @@
                     <li>TCP 22 ssh</li>
                     <li>TCP 80 http</li>
                     <li>TCP 443 https</li>
+                </ul>
+            </section>
+
+            <section id="servers-status">
+                <h2><a href="#servers-status">GrapheneOS Production Server Status</a></h2>
+
+                <ul>
+                    <li><a href="https://nodeping.com/reports/statusevents/3FL97F6RRQHJIOWL">NodePing Server Status Page</a></li>
                 </ul>
             </section>
         </main>


### PR DESCRIPTION
### Description
This adds a section to the GrapheneOS servers page of the website which includes a link to the production servers status page hosted by NodePing. This PR comes after feedback in #947 that this information is more suitable for the servers article.

### Related Issue
Closes #860 