### PR TITLE
Fix typo in static/features.html

### DIFF
--- a/static/features.html
+++ b/static/features.html
@@ -280,7 +280,7 @@
                         both the hardware level via configuring the USB controller and also at the
                         OS level in the kernel to provide a second layer of defense. It disables the
                         data lines at a hardware level as soon as the existing connections end which
-                        happens right away if there were new USB connections. It also disables USB-C
+                        happens right away if there were no USB connections. It also disables USB-C
                         alternate modes including DisplayPort at both the OS and hardware level.</p>
 
                         <p>Our implementation is far more secure than Android's standard USB HAL


### PR DESCRIPTION
This fixes a typo in the new documentation of the new USB-C/pogo-pin control.