### PR TITLE
Restore paragraph to previous position

### DIFF
--- a/static/faq.html
+++ b/static/faq.html
@@ -153,6 +153,11 @@
                         <li>Pixel 5a (barbet)</li>
                     </ul>
 
+                    <p>The release tags for these devices have official builds and updates
+                    available. These devices meet the stringent privacy and security standards and
+                    have substantial upstream and downstream hardening specific to the
+                    devices.</p>
+
                     <p>The following devices are end-of-life, no longer receive firmware or most
                     driver security updates, and receive extended support from GrapheneOS as part
                     of the main releases with all GrapheneOS changes including all of the latest
@@ -177,11 +182,6 @@
 
                     <p>We provide extended support releases as a stopgap for users to transition
                     to the far more secure current generation devices.</p>
-
-                    <p>The release tags for these devices have official builds and updates
-                    available. These devices meet the stringent privacy and security standards and
-                    have substantial upstream and downstream hardening specific to the
-                    devices.</p>
 
                     <p>Many other devices are supported by GrapheneOS at a source level, and it can be
                     built for them without modifications to the existing GrapheneOS source tree. Device


### PR DESCRIPTION
I believe the intent is that this paragraph:
> The release tags for these devices have official builds and updates available. [...] These devices meet the stringent privacy and security standards [...]

...should **_immediately_** follow the paragraph that starts:
> GrapheneOS has official production support for the following devices

...so that the "official builds and updates" language and the "stringent standards" language are applied to the list of production devices.

However, at present the EOL/ESR devices are listed in between the list of "official production support" devices and the "official builds / stringent privacy and security standards" paragraph.  I believe this is due to an oversight.

In particular, I believe commit f8f435bc9e768b95736d0aab0d3391a9c3488757 of 2021-11-01 accidentally separated the two paragraphs, and they have been separated since.  This commit moves the "stringent privacy and security" paragraph back to its previous location.