### PR TITLE
Update build instruction with new "cur" release config alias

### DIFF
--- a/static/build.html
+++ b/static/build.html
@@ -401,7 +401,7 @@ m aapt2</pre>
 
                     <p>Select the desired build target (<code>husky</code> is the Pixel 8 Pro):</p>
 
-                    <pre>lunch husky-ap2a-user</pre>
+                    <pre>lunch husky-cur-user</pre>
 
                     <p>For past stable tags and legacy branches, don't pass the Android release:</p>
 


### PR DESCRIPTION
With https://github.com/GrapheneOS/platform_build_release/commit/3c74e759fa2140a355725072099f6ef20ae54447 now in development 14 branch, prepare build instruction with the aforementioned commit in mind.