### PR TITLE
Update intervals for system update check

### DIFF
--- a/static/faq.html
+++ b/static/faq.html
@@ -842,7 +842,7 @@
                     <ul>
                         <li>
                             <p>The GrapheneOS System Updater app fetches update metadata from
-                            https://releases.grapheneos.org/<var>DEVICE</var>-<var>CHANNEL</var> approximately once every four hours
+                            https://releases.grapheneos.org/<var>DEVICE</var>-<var>CHANNEL</var> approximately once every six hours
                             when connected to a permitted network for updates.</p>
                             <p>Once an update is available, it tries to download
                             https://releases.grapheneos.org/<var>DEVICE</var>-incremental-<var>OLD_VERSION</var>-<var>NEW_VERSION</var>.zip

--- a/static/usage.html
+++ b/static/usage.html
@@ -396,7 +396,7 @@
                 <h2><a href="#updates">Updates</a></h2>
 
                 <p>The update system implements automatic background updates. It checks for updates
-                approximately once every four hours when there's network connectivity and then
+                approximately once every six hours when there's network connectivity and then
                 downloads and installs updates in the background. It will pick up where it left off if
                 downloads are interrupted, so you don't need to worry about interrupting it.
                 Similarly, interrupting the installation isn't a risk because updates are installed to


### PR DESCRIPTION
Update check interval is increased from 4 hours to 6 hours since the 2024062000 release. Latest extended support release for Pixel 5 series should also cover this.