### PR TITLE
FAQ: fix typo in time security list item

### DIFF
--- a/static/faq.html
+++ b/static/faq.html
@@ -888,7 +888,7 @@
                             second precision.</p>
 
                             <p>This is a full replacement for Android's standard network time
-                            update implementation, which uses unauthentication SNTP (Simple
+                            update implementation, which uses unauthenticated SNTP (Simple
                             Network Time Protocol) with fallback to the cellular network when it's
                             not available (GNSS can also be used as a time source but is disabled
                             by default, and OEMs can choose the priority order). Network time


### PR DESCRIPTION
"unauthentication SNTP" -> "unauthenticated SNTP".