### PR TITLE
Explain how to fix WebUSB of Chromium on Ubuntu

### DIFF
--- a/static/install/web.html
+++ b/static/install/web.html
@@ -130,7 +130,7 @@
                 <p>Officially supported browsers for the web install method:</p>
 
                 <ul>
-                    <li>Chromium (outside Ubuntu, since they ship a broken Snap package without working WebUSB)</li>
+                    <li>Chromium (on Ubuntu you need to run <code>sudo snap connect chromium:raw-usb</code> to fix WebUSB)</li>
                     <li>Vanadium (GrapheneOS)</li>
                     <li>Google Chrome</li>
                     <li>Microsoft Edge</li>


### PR DESCRIPTION
The documentation previously claimed that snap-packaged chromium has WebUSB broken on Ubuntu. This is not entirely accurate as it is just disabled. To enable it one needs to run one simple command after which flashing from Web starts working. (I've tested this.)

This commit updates the website to change the claim into explaining which command is needed.