### PR TITLE
web-install + cli: updated guide docs on removing non-stock key while in fastboot

### DIFF
--- a/static/install/cli.html
+++ b/static/install/cli.html
@@ -650,8 +650,8 @@ curl -O https://releases.grapheneos.org/<var>DEVICE_NAME</var>-factory-<var>VERS
 
                     <p>The GrapheneOS factory images flash a non-stock Android Verified Boot key which
                     needs to be erased to fully revert back to a stock device state. Before flashing the
-                    stock factory images and before locking the bootloader, you should erase the custom
-                    Android Verified Boot key to untrust it:</p>
+                    stock factory images, you should bring the device into fastboot mode and make sure the
+                    bootloader is unlocked. Then erase the custom Android Verified Boot key to untrust it:</p>
 
                     <pre>fastboot erase avb_custom_key</pre>
                 </section>

--- a/static/install/cli.html
+++ b/static/install/cli.html
@@ -650,7 +650,7 @@ curl -O https://releases.grapheneos.org/<var>DEVICE_NAME</var>-factory-<var>VERS
 
                     <p>The GrapheneOS factory images flash a non-stock Android Verified Boot key which
                     needs to be erased to fully revert back to a stock device state. Before flashing the
-                    stock factory images, you should bring the device into fastboot mode and make sure the
+                    stock factory images, you should boot the device into fastboot mode and make sure the
                     bootloader is unlocked. Then erase the custom Android Verified Boot key to untrust it:</p>
 
                     <pre>fastboot erase avb_custom_key</pre>

--- a/static/install/web.html
+++ b/static/install/web.html
@@ -459,7 +459,7 @@
 
                     <p>The GrapheneOS factory images flash a non-stock Android Verified Boot key which
                     needs to be erased to fully revert back to a stock device state. Before flashing the
-                    stock factory images, you should bring the device into fastboot mode and make sure the
+                    stock factory images, you should boot the device into fastboot mode and make sure the
                     bootloader is unlocked. Then erase the custom Android Verified Boot key to untrust it:</p>
 
                     <button id="remove-custom-key-button" disabled="">Remove non-stock key</button>

--- a/static/install/web.html
+++ b/static/install/web.html
@@ -459,8 +459,8 @@
 
                     <p>The GrapheneOS factory images flash a non-stock Android Verified Boot key which
                     needs to be erased to fully revert back to a stock device state. Before flashing the
-                    stock factory images and before locking the bootloader, you should erase the custom
-                    Android Verified Boot key to untrust it:</p>
+                    stock factory images, you should bring the device into fastboot mode and make sure the
+                    bootloader is unlocked. Then erase the custom Android Verified Boot key to untrust it:</p>
 
                     <button id="remove-custom-key-button" disabled="">Remove non-stock key</button>
 


### PR DESCRIPTION
The current web installer documentation is not clear about the required phone state while removing the non-stock key.
The phone should be in *fastboot* mode and bootloader should be unlocked. Otherwise it's not detected by WebUSB.