### PR TITLE
Remove EOL Android 11 from web-install OSes

### DIFF
--- a/static/install/web.html
+++ b/static/install/web.html
@@ -119,7 +119,6 @@
                     <li>Linux Mint Debian Edition 6 (follow Debian 12 instructions)</li>
                     <li>ChromeOS</li>
                     <li>GrapheneOS</li>
-                    <li>Android 11 with Play Protect certification</li>
                     <li>Android 12 with Play Protect certification</li>
                     <li>Android 13 with Play Protect certification</li>
                     <li>Android 14 with Play Protect certification</li>


### PR DESCRIPTION
Android 11 no longer receives any kind of security support. Therefore, it might make sense to not officially support it for the web install anymore.