### PR TITLE
Update documentation to account for Safety Center UI

### DIFF
--- a/static/faq.html
+++ b/static/faq.html
@@ -1138,8 +1138,8 @@
                     as part of Widevine provisioning. This is another form of key provisioning for
                     per-app keys that are used when playing DRM protected media. DRM support is
                     enabled in the OS by default but we don't include any apps using it by default,
-                    since it's disabled in Vanadium. A setting is added at <b>Settings&#160;
-                    <span aria-label="and then">></span> Network &amp; Internet#160;<span aria-label="and then">></span> 
+                    since it's disabled in Vanadium. A setting is added at <b>Settings&#160;<span
+                    aria-label="and then">></span> Network &amp; Internet#160;<span aria-label="and then">></span> 
                     Widevine provisioning</b> for switching to directly using the Google service if you prefer.</p>
 
                     <p>Most other connections made by the OS itself are made based on your chosen

--- a/static/faq.html
+++ b/static/faq.html
@@ -645,8 +645,8 @@
                     <p>As of Android 12, the user is notified when an app reads clipboard content
                     which was set by a different app. This notice is enabled by default and can be
                     toggled under <b>Settings&#160;<span aria-label="and then">></span>
-                    Security &amp; privacy&#160;<span aria-label="and then">></span> Privacy&#160;
-                    <span aria-label="and then">></span> Show clipboard access</b>.</p>
+                    Security &amp; privacy&#160;<span aria-label="and then">></span> Privacy&#160;<span
+                    aria-label="and then">></span> Show clipboard access</b>.</p>
                 </article>
 
                 <article id="hardware-identifiers">

--- a/static/faq.html
+++ b/static/faq.html
@@ -645,7 +645,7 @@
                     <p>As of Android 12, the user is notified when an app reads clipboard content
                     which was set by a different app. This notice is enabled by default and can be
                     toggled under <b>Settings&#160;<span aria-label="and then">></span>
-                    Security & privacy&#160;<span aria-label="and then">></span> Privacy&#160;
+                    Security &amp; privacy&#160;<span aria-label="and then">></span> Privacy&#160;
                     <span aria-label="and then">></span> Show clipboard access</b>.</p>
                 </article>
 

--- a/static/faq.html
+++ b/static/faq.html
@@ -645,8 +645,8 @@
                     <p>As of Android 12, the user is notified when an app reads clipboard content
                     which was set by a different app. This notice is enabled by default and can be
                     toggled under <b>Settings&#160;<span aria-label="and then">></span>
-                    Privacy&#160;<span aria-label="and then">></span> Show clipboard
-                    access</b>.</p>
+                    Security & privacy&#160;<span aria-label="and then">></span> Privacy&#160;
+                    <span aria-label="and then">></span> Show clipboard access</b>.</p>
                 </article>
 
                 <article id="hardware-identifiers">
@@ -1138,9 +1138,9 @@
                     as part of Widevine provisioning. This is another form of key provisioning for
                     per-app keys that are used when playing DRM protected media. DRM support is
                     enabled in the OS by default but we don't include any apps using it by default,
-                    since it's disabled in Vanadium. A setting is added at Settings ➔ Network &amp;
-                    Internet ➔ Widevine provisioning for switching to directly using the Google
-                    service if you prefer.</p>
+                    since it's disabled in Vanadium. A setting is added at <b>Settings&#160;
+                    <span aria-label="and then">></span> Network &amp; Internet#160;<span aria-label="and then">></span> 
+                    Widevine provisioning</b> for switching to directly using the Google service if you prefer.</p>
 
                     <p>Most other connections made by the OS itself are made based on your chosen
                     carrier. The OS has a database of APN and other carrier configuration settings

--- a/static/features.html
+++ b/static/features.html
@@ -831,7 +831,7 @@
 
                     <p>The wipe does not require a reboot and cannot be interrupted. It can be set
                     up at <b>Settings&#160;<span aria-label="and then">></span>Security &amp; privacy&#160;<span
-                    aria-label="and then">></span> Device unlock&#160; <span
+                    aria-label="and then">></span> Device unlock&#160;<span
                     aria-label="and then">></span> Duress Password</b> in the owner profile. Both a
                     duress PIN and password will need to be set to account for different profiles
                     that may have different unlock methods.</p>

--- a/static/features.html
+++ b/static/features.html
@@ -602,8 +602,8 @@
                     data due to being denied, GrapheneOS creates a notification that can be
                     easily disabled. The Sensors permission can be set to be disabled by default
                     for user installed apps in <b>Settings&#160;<span aria-label="and
-                    then">></span> Security & privacy&#160;<span aria-label="and
-                    then">></span> More security & privacy</b>.</p>
+                    then">></span> Security &amp; privacy&#160;<span aria-label="and
+                    then">></span> More security &amp; privacy</b>.</p>
                 </section>
 
                 <section id="storage-scopes">
@@ -700,8 +700,8 @@
                     name of the screenshot which is fully visible to the user and can be easily
                     modified by them without a third-party tool. GrapheneOS includes a toggle for
                     turning this metadata back on in <b>Settings&#160;<span aria-label="and
-                    then">></span> Security & privacy&#160;<span aria-label="and
-                    then">></span> More security & privacy</b> since some users may find it to be useful.</p>
+                    then">></span> Security &amp; privacy&#160;<span aria-label="and
+                    then">></span> More security &amp; privacy</b> since some users may find it to be useful.</p>
                 </section>
 
                 <section id="closed-device-identifier-leaks">
@@ -830,7 +830,7 @@
                     with any such prompt in the OS).</p>
 
                     <p>The wipe does not require a reboot and cannot be interrupted. It can be set
-                    up at <b>Settings&#160;<span aria-label="and then">></span>Security & privacy&#160; <span
+                    up at <b>Settings&#160;<span aria-label="and then">></span>Security &amp; privacy&#160; <span
                     aria-label="and then">></span> Device unlock&#160; <span
                     aria-label="and then">></span> Duress Password</b> in the owner profile. Both a
                     duress PIN and password will need to be set to account for different profiles

--- a/static/features.html
+++ b/static/features.html
@@ -830,7 +830,7 @@
                     with any such prompt in the OS).</p>
 
                     <p>The wipe does not require a reboot and cannot be interrupted. It can be set
-                    up at <b>Settings&#160;<span aria-label="and then">></span>Security &amp; privacy&#160; <span
+                    up at <b>Settings&#160;<span aria-label="and then">></span>Security &amp; privacy&#160;<span
                     aria-label="and then">></span> Device unlock&#160; <span
                     aria-label="and then">></span> Duress Password</b> in the owner profile. Both a
                     duress PIN and password will need to be set to account for different profiles

--- a/static/features.html
+++ b/static/features.html
@@ -602,7 +602,8 @@
                     data due to being denied, GrapheneOS creates a notification that can be
                     easily disabled. The Sensors permission can be set to be disabled by default
                     for user installed apps in <b>Settings&#160;<span aria-label="and
-                    then">></span> Privacy</b>.</p>
+                    then">></span> Security & privacy&#160;<span aria-label="and
+                    then">></span> More security & privacy</b>.</p>
                 </section>
 
                 <section id="storage-scopes">
@@ -699,7 +700,8 @@
                     name of the screenshot which is fully visible to the user and can be easily
                     modified by them without a third-party tool. GrapheneOS includes a toggle for
                     turning this metadata back on in <b>Settings&#160;<span aria-label="and
-                    then">></span> Privacy</b> since some users may find it to be useful.</p>
+                    then">></span> Security & privacy&#160;<span aria-label="and
+                    then">></span> More security & privacy</b> since some users may find it to be useful.</p>
                 </section>
 
                 <section id="closed-device-identifier-leaks">
@@ -828,7 +830,8 @@
                     with any such prompt in the OS).</p>
 
                     <p>The wipe does not require a reboot and cannot be interrupted. It can be set
-                    up at <b>Settings&#160;<span aria-label="and then">></span> Security&#160; <span
+                    up at <b>Settings&#160;<span aria-label="and then">></span>Security & privacy&#160; <span
+                    aria-label="and then">></span> Device unlock&#160; <span
                     aria-label="and then">></span> Duress Password</b> in the owner profile. Both a
                     duress PIN and password will need to be set to account for different profiles
                     that may have different unlock methods.</p>

--- a/static/usage.html
+++ b/static/usage.html
@@ -376,8 +376,8 @@
 
                 <p>GrapheneOS disables showing the characters as passwords are typed by default. You
                 can enable this in <b>Settings&#160;<span aria-label="and then">></span>
-                Security &amp; privacy&#160;<span aria-label="and then">></span> Privacy&#160;
-                <span aria-label="and then">></span> Show passwords</b>.</p>
+                Security &amp; privacy&#160;<span aria-label="and then">></span> Privacy&#160;<span
+                aria-label="and then">></span> Show passwords</b>.</p>
 
                 <p>Third party accessibility services can be installed and activated. This
                 includes the ones made by Google. Most of these will work but some may have a hard

--- a/static/usage.html
+++ b/static/usage.html
@@ -814,7 +814,7 @@
                 for each boot via the shared randomized values.</p>
 
                 <p>This feature can be disabled via <b>Settings&#160;<span aria-label="and
-                then">></span> Security &amp; privacy &#160;<span aria-label="and then">></span> 
+                then">></span> Security &amp; privacy&#160;<span aria-label="and then">></span> 
                 Exploit protection&#160;<span aria-label="and then">></span> Secure app spawning</b> 
                 if you prefer to have faster cold start app spawning time and lower
                 app process memory usage instead of the substantial security benefits and the

--- a/static/usage.html
+++ b/static/usage.html
@@ -376,7 +376,8 @@
 
                 <p>GrapheneOS disables showing the characters as passwords are typed by default. You
                 can enable this in <b>Settings&#160;<span aria-label="and then">></span>
-                Privacy</b>.</p>
+                Security &amp; privacy&#160;<span aria-label="and then">></span> Privacy&#160;
+                <span aria-label="and then">></span> Show passwords</b>.</p>
 
                 <p>Third party accessibility services can be installed and activated. This
                 includes the ones made by Google. Most of these will work but some may have a hard
@@ -813,8 +814,9 @@
                 for each boot via the shared randomized values.</p>
 
                 <p>This feature can be disabled via <b>Settings&#160;<span aria-label="and
-                then">></span> Security&#160;<span aria-label="and then">></span> Secure app
-                spawning</b> if you prefer to have faster cold start app spawning time and lower
+                then">></span> Security &amp; privacy &#160;<span aria-label="and then">></span> 
+                Exploit protection&#160;<span aria-label="and then">></span> Secure app spawning</b> 
+                if you prefer to have faster cold start app spawning time and lower
                 app process memory usage instead of the substantial security benefits and the
                 removal of the only known remaining direct device identifiers across profiles (i.e.
                 not depending on fingerprinting global configuration, available storage space, etc.
@@ -1250,7 +1252,8 @@
                 prevent inspecting or modifying the app in a weak attempt to hide their code and API
                 from security researchers. GrapheneOS allows users to disable <b>Native code
                 debugging</b> via a toggle in <b>Settings&#160;<span aria-label="and then">></span>
-                Security</b> to improve the app sandbox and this can interfere with apps debugging their
+                Security &amp; privacy&#160;<span aria-label="and then">></span> Exploit protection</b> 
+                to improve the app sandbox and this can interfere with apps debugging their
                 own code to add a barrier to analyzing the app. You should try enabling this again if you've
                 disabled it and are encountering compatibility issues with these kinds of apps.</p>
 


### PR DESCRIPTION
This PR updates the documentation across features, FAQ, and Usage to use the new path for settings that have been migrated to Safety Center.