### PR TITLE
Remove mention that fwupd workaround is not needed for Pixel 4a and later from webinstall docs

### DIFF
--- a/static/install/web.html
+++ b/static/install/web.html
@@ -198,8 +198,6 @@
             <section id="working-around-fwupd-bug-on-linux-distributions">
                 <h2><a href="#working-around-fwupd-bug-on-linux-distributions">Working around fwupd bug on Linux distributions</a></h2>
 
-                <p><em>This is no longer required for the Pixel 4a (5G) and later.</em></p>
-
                 <p>Debian stable and Ubuntu have an outdated fwupd package with a bug breaking
                 connecting to Android's bootloader interface (fastboot) while fwupd is running
                 since it tries to connect to arbitrary devices. This section can be skipped on


### PR DESCRIPTION
Hi, thanks for all of your work on GrapheneOS and the excellent documentation.

I am proposing to remove the line in the webinstall docs that indicates that the fwupd.service workaround is no longer required for 4a and later devices; I recently went through the webinstall instructions with a newer Pixel device on Debian bookworm, which still has fwupd < 1.9.10, and required the workaround to proceed.