### PR TITLE
Fix typo in build.html

### DIFF
--- a/static/build.html
+++ b/static/build.html
@@ -190,7 +190,7 @@
                     hardware-level USB-C port control. There's also a lot of device-specific work to
                     work around or resolve memory corruption bugs uncovered by our features. Most
                     devices are also missing a lot of standard hardware-based security features we
-                    use such as hardware memory taggings so those features will inherently not be
+                    use such as hardware memory tagging so those features will inherently not be
                     possible to port to a device not capable of it.</p>
                 </section>
 


### PR DESCRIPTION
Fix typo: "memory taggings" to "memory tagging"