### PR TITLE
Remove Pixel 5a from device lifetime table

### DIFF
--- a/static/faq.html
+++ b/static/faq.html
@@ -518,11 +518,6 @@
                             <td>October 2026</td>
                             <td>5 years</td>
                         </tr>
-                        <tr>
-                            <td>Google Pixel 5a</td>
-                            <td>August 2024</td>
-                            <td>3 years</td>
-                        </tr>
                     </table>
 
                 </article>


### PR DESCRIPTION
Pixel 5a is EOL, so it makes sense to remove it from the table.