### PR TITLE
fingerprint to hash

### DIFF
--- a/static/install/index.html
+++ b/static/install/index.html
@@ -56,7 +56,7 @@
             packages, along with understanding the process enough to avoid blindly trusting the
             instructions from our site. The web-based installation approach avoids needing any
             software beyond a browser with WebUSB support and you can still avoid trusting our
-            server infrastructure by checking the verified boot key fingerprint.</p>
+            server infrastructure by checking the verified boot key hash.</p>
         </main>
         {% include "footer.html" %}
     </body>


### PR DESCRIPTION
CLI install guide and Web installer each use the designation hash and never fingerprint.