### PR TITLE
restoring a previous paragraph

### DIFF
--- a/static/install/cli.html
+++ b/static/install/cli.html
@@ -105,9 +105,7 @@
             <section id="prerequisites">
                 <h2><a href="#prerequisites">Prerequisites</a></h2>
 
-                <p>You need a computer for running the web installer with at least 2GB of free
-                memory available and 32GB of free storage space. The web installer can be run on an
-                Android phone or tablet, unlike the command-line installation.</p>
+                <p>You should have at least 2GB of free memory available and 8GB of free storage space.</p>
 
                 <p>You need a USB cable for attaching the device to the computer performing the
                 installation. Whenever possible, use the high quality standards compliant USB-C


### PR DESCRIPTION
In commit https://github.com/GrapheneOS/grapheneos.org/commit/c7e634364aa2e2774a9cdbe5172f0983f4d827ba#diff-81aefcb9b7a401823bfb4558719f8aa4dbce2ea47cad509c7cc2111abf31d7d5L108 the paragraph for the requirements was replaced by those for the web installer.