### PR TITLE
Add section on devices with GrapheneOS preinstalled

### DIFF
--- a/static/build.html
+++ b/static/build.html
@@ -83,6 +83,7 @@
                                 <a href="#kernel">Kernel</a>
                                 <ul>
                                     <li><a href="#kernel-emulator">Emulator</a></li>
+                                    <li><a href="#kernel-microdroid">Microdroid</a></li>
                                     <li><a href="#kernel-9th-generation-pixels">9th generation Pixels</a></li>
                                     <li><a href="#kernel-8th-generation-pixels">8th generation Pixels</a></li>
                                     <li><a href="#kernel-7th-generation-pixels">7th generation Pixels</a></li>
@@ -755,6 +756,26 @@ repo sync -j8</pre>
 
                         <p>You can configure the kernel version used for the x86_64 emulator in
                         <code>device/generic/goldfish/board/kernel/x86_64.mk</code>.</p>
+                    </section>
+
+                    <section id="#kernel-microdroid">
+                        <h4><a href="#kernel-microdroid">Microdroid</a></h4>
+
+                        <p>To sync the 6.6 kernel sources:</p>
+
+                        <pre>mkdir -p android/kernel/6.6
+cd android/kernel/6.6
+repo init -u https://github.com/GrapheneOS/kernel_manifest-6.6.git -b 15
+repo sync -j8</pre>
+
+                        <p>To build the 6.6 kernel image for microdroid:</p>
+
+                        <pre>tools/bazel run //common:kernel_aarch64_microdroid_dist --lto=full -- --dist_dir=microdroid_dist</pre>
+
+                        <p>Replace the prebuilt kernel image in the OS source tree at
+                        <code>packages/modules/Virtualization/microdroid/kernel/android15-6.6/arm64/kernel-6.6</code> with your image
+                        <code>microdroid_dist/Image</code>.</p>
+
                     </section>
 
                     <section id="kernel-9th-generation-pixels">

--- a/static/faq.html
+++ b/static/faq.html
@@ -110,6 +110,7 @@
                     <li><a href="#bundled-apps">Why aren't my favorite apps bundled with GrapheneOS?</a></li>
                     <li><a href="#roadmap">What is the roadmap for GrapheneOS?</a></li>
                     <li><a href="#install">How do I install GrapheneOS?</a></li>
+                    <li><a href="#preinstalled-devices">Can I buy a device with GrapheneOS preinstalled?</a></li>
                     <li><a href="#build">How do I build GrapheneOS?</a></li>
                     <li><a href="#donate">How can I donate to GrapheneOS?</a></li>
                     <li><a href="#upstream">Does GrapheneOS make upstream contributions?</a></li>
@@ -1832,6 +1833,47 @@
                 installation approach is no less secure and avoids needing any software beyond a
                 browser with WebUSB support.</p>
             </article>
+
+            <article id="preinstalled-devices">
+                <h2><a href="#preinstalled-devices">Can I buy a device with GrapheneOS preinstalled?</a></h2>
+                
+                <p>Can I buy a device with GrapheneOS preinstalled?</p>
+                
+                <p>There are various companies selling devices with GrapheneOS, 
+                something which is permitted by the project's licensing provided 
+                that they make it clear that they're not GrapheneOS or officially 
+                associated with the project.</p>
+                
+                <p><strong>We are currently not affiliated with or endorse any 
+                company selling devices with GrapheneOS. Our official recommendation 
+                is to buy a supported device and install GrapheneOS yourself.</strong></p>
+                
+                <p>Our official <a href="https://grapheneos.org/install/web">web installer</a>
+                is easy to use, and our <a href="https://grapheneos.org/contact#community">community</a> 
+                is happy to help with the process should that be needed. On top of that, doing it 
+                yourself will also likely be a lot cheaper, as you're avoiding having to pay the premium 
+                of having someone else install GrapheneOS for you.</p>
+                
+                <p>If you decide to buy a device with GrapheneOS installed regardless, 
+                here are the things you should pay attention to before doing so, 
+                as well as the things you should do after receiving the device:</p>
+                
+                <ol>
+                    <li>Make sure that you're not buying an end-of-life or near end-of-life device. 
+                    You should consult our <a href="https://grapheneos.org/faq#recommended-devices">
+                    recommended devices</a> section and choose one of the devices listed there.</li>
+                    <li>Verify that the device you have purchased is running genuine GrapheneOS. 
+                    You can do this by checking the verified boot key hash. We provide the steps to 
+                    do that in our <a href="https://grapheneos.org/install/web#verified-boot-key-hash">
+                    post-install steps</a>.</li>
+                    <li>After verifying that you're running genuine GrapheneOS, you should 
+                    <a href="https://support.google.com/pixelphone/answer/4596836?hl=en#zippy=%2Cwith-your-phones-buttons-advanced">
+                    factory reset the device from recovery</a> to make sure that it has not been tampered with. 
+                    This will wipe all your data, so make sure to do it before you start using your device.</li>
+                    <li>After factory resetting the device, we recommend setting up local or remote attestation 
+                    via our <a href="https://grapheneos.org/install/web#hardware-based-attestation">Auditor app</a>.</li>
+                </ol>
+                </article>
 
             <article id="build">
                 <h2><a href="#build">How do I build GrapheneOS?</a></h2>


### PR DESCRIPTION
This PR adds a section regarding devices with GrapheneOS preinstalled. It is meant to do the following:

1. Make it clear that we're not affiliated with any companies selling devices with GrapheneOS preinstalled.
2. Reiterate that our recommendation is for people to do it themselves with our web installer.
3. Help users who decide to purchase a device from a third-party anyway to make an informed decision and ensure they're running unmodified and clean GrapheneOS.