### PR TITLE
Fixed "Changes since" release codes

### DIFF
--- a/static/releases.html
+++ b/static/releases.html
@@ -583,7 +583,7 @@
                         <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/2024120200">2024120200</a> (Pixel 6, Pixel 6 Pro, Pixel 6a, Pixel 7, Pixel 7 Pro, Pixel 7a, Pixel Tablet, Pixel Fold, Pixel 8, Pixel 8 Pro, Pixel 8a, Pixel 9, Pixel 9 Pro, Pixel 9 Pro XL, Pixel 9 Pro Fold, emulator, generic, other targets)</li>
                     </ul>
 
-                    <p>Changes since the 2024111700 release:</p>
+                    <p>Changes since the 2024112700 release:</p>
 
                     <ul>
                         <li>full 2024-12-01 security patch level</li>
@@ -603,7 +603,7 @@
                         <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/2024112700">2024112700</a> (Pixel 6, Pixel 6 Pro, Pixel 6a, Pixel 7, Pixel 7 Pro, Pixel 7a, Pixel Tablet, Pixel Fold, Pixel 8, Pixel 8 Pro, Pixel 8a, Pixel 9, Pixel 9 Pro, Pixel 9 Pro XL, Pixel 9 Pro Fold, emulator, generic, other targets)</li>
                     </ul>
 
-                    <p>Changes since the 2024111700 release:</p>
+                    <p>Changes since the 2024111800 release:</p>
 
                     <ul>
                         <li>Settings: revert our previous attempt at disabling Bluetooth contact sharing by default for hands-free calling devices in our <a href="#2024111700">2024111700</a> release because it didn't address an upstream Android security bug and having the toggle off by default caused the upstream bug to impact pairing directly in the Settings app (foreground) if the user would have toggled it off instead of only outside the Settings app such as through the Bluetooth Quick Tile (background)</li>


### PR DESCRIPTION
2024120200 and 2024112700 both said "Changes since the 2024111700 release:", which is incorrect.