### PR TITLE
Fixed "Changes since" release codes (again)

### DIFF
--- a/static/releases.html
+++ b/static/releases.html
@@ -5355,7 +5355,7 @@
                         <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/SQ3A.220705.003.A1.2022080300">SQ3A.220705.003.A1.2022080300</a> (Pixel 4, Pixel 4 XL, Pixel 4a, Pixel 4a (5G), Pixel 5, Pixel 5a, Pixel 6, Pixel 6 Pro, emulator, generic, other targets)</li>
                     </ul>
 
-                    <p>Changes since the 2022072700 release:</p>
+                    <p>Changes since the 2022073000 release:</p>
 
                     <ul>
                         <li>overhaul the implementation of multiple features to prepare for the Android 13 migration</li>
@@ -8663,7 +8663,7 @@
                         <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/QP1A.191105.004.2019.11.04.23">QP1A.191105.004.2019.11.04.23</a> (Pixel 2, Pixel 2 XL, emulator, generic, other targets)</li>
                     </ul>
 
-                    <p>Changes since the 2019.09.25.00 release:</p>
+                    <p>Changes since the 2019.10.07.21 release:</p>
 
                     <ul>
                         <li>full 2019-11-01 security patch level</li>


### PR DESCRIPTION
2022080300 and 2019.11.04.23 got fixed this time