### PR TITLE
Mention the digital ID feature in italian IO app is forbidding GrapheneOS

### DIFF
--- a/static/articles/attestation-compatibility-guide.html
+++ b/static/articles/attestation-compatibility-guide.html
@@ -128,6 +128,7 @@
 
                 <ul>
                     <li><a href="https://play.google.com/store/apps/details?id=com.authy.authy">Authy</a></li>
+                    <li><a href="https://play.google.com/store/apps/details?id=it.pagopa.io.app">IO (digital ID feature)</a></li>
                     <li><a href="https://play.google.com/store/apps/details?id=com.revolut.revolut">Revolut</a></li>
                     <li><a href="https://play.google.com/store/apps/details?id=com.revolut.business">Revolut Business</a></li>
                     <li><a href="https://play.google.com/store/apps/details?id=com.mcdonalds.app">McDonald's</a> (US app)</li>


### PR DESCRIPTION
Clearly uses Play Integrity based on the [code](https://github.com/pagopa/io-react-native-wallet/blob/master/src/wallet-instance/README.md) and their [FAQ (italian)](https://io.italia.it/documenti-su-io/faq/#n1_12). They target Android 8 so it's obviously not intended as a security feature.

