### PR TITLE
Fix typo in attestation-compatibility-guide.html

### DIFF
--- a/static/articles/attestation-compatibility-guide.html
+++ b/static/articles/attestation-compatibility-guide.html
@@ -45,7 +45,7 @@
             It also avoids an unnecessary dependency on Google Play services and Google's
             Play Integrity servers.</p>
 
-            <p>The standard hardware attestation API can be used to verify the authencity/integrity
+            <p>The standard hardware attestation API can be used to verify the authenticity/integrity
             of the hardware, firmware, OS and the app running on it. It provides a verified boot key
             fingerprint for the OS for permitting secure aftermarket operating systems. The app id,
             signing key fingerprint(s) and version code of the app enabling hardware attestation are


### PR DESCRIPTION
fix typo: "authencity" to "authenticity"