### PR TITLE
Clarify required pwd for path export commands

### DIFF
--- a/static/install/cli.html
+++ b/static/install/cli.html
@@ -258,7 +258,9 @@ tar xvf platform-tools_r35.0.2-darwin.zip</pre>
 tar xvf platform-tools_r35.0.2-win.zip</pre>
 
                     <p>Next, add the tools to your <code>PATH</code> in the current shell so they can be
-                    used without referencing them by file path, enabling usage by the flashing script.</p>
+                    used without referencing them by file path, enabling usage by the flashing script.
+		    The following commands must be run from within the extracted <code>platform-tools_r35.0.2-*.zip</code>
+		    directory.</p>
 
                     <p>On Debian, Ubuntu and macOS:</p>
 


### PR DESCRIPTION
I just helped someone who was blocked on the CLI install because they didn't realize they needed to be in a specific directory (the extracted platform-tools zip) for the path export commands for the standalone platform-tools to work properly. This addition to the documentation could help prevent others from getting blocked with the same problem. 

This person (and most people) would have had an easier time with the web installer, but this didn't work for them because they were using ubuntu and didn't realize that chromium was installed with a snap with web-usb disabled. PR #984  being merged would have allowed them to use the web installer which probably would have been better overall. 

