### PR TITLE
Removed US McDonalds app from list of apps banning GrapheneOS

### DIFF
--- a/static/articles/attestation-compatibility-guide.html
+++ b/static/articles/attestation-compatibility-guide.html
@@ -149,7 +149,6 @@
                     <li><a href="https://play.google.com/store/apps/details?id=it.pagopa.io.app">IO</a> (Italian government app which uses it for the digital wallet feature)</li>
                     <li><a href="https://play.google.com/store/apps/details?id=com.revolut.revolut">Revolut</a></li>
                     <li><a href="https://play.google.com/store/apps/details?id=com.revolut.business">Revolut Business</a></li>
-                    <li><a href="https://play.google.com/store/apps/details?id=com.mcdonalds.app">McDonald's</a> (US app)</li>
                     <li><a href="https://play.google.com/store/apps/details?id=com.mcdonalds.mobileapp">McDonald's</a> (International app used for many but not all countries)</li>
                     <li><a href="https://play.google.com/store/apps/details?id=de.tk.tkapp">TK-App</a></li>
                 </ul>


### PR DESCRIPTION
Removed US McDonalds app from list of apps banning GrapheneOS as it appears they have made changes that allow the app to work for us :)
![Screenshot_20241220-153707~2.png](https://github.com/user-attachments/assets/f7ca753f-1bba-4722-80ca-de644e6e5e4f)

![Screenshot_20241220-153725.png](https://github.com/user-attachments/assets/77a1a57a-b259-4fd3-b73b-a1bc559d9c60)

![Screenshot_20241220-153730~4.png](https://github.com/user-attachments/assets/07528730-2dc9-444e-965c-3d070219485c)

![Screenshot_20241220-154624~3.png](https://github.com/user-attachments/assets/07b8a311-e42c-4a25-a99f-991178fd6700)

