### PR TITLE
list "symptoms" of successful entry to fastboot mode

### DIFF
--- a/static/install/cli.html
+++ b/static/install/cli.html
@@ -333,6 +333,11 @@ Installed as /home/username/platform-tools/fastboot</pre>
                 <p>Alternatively, turn off the device, then boot it up while holding the volume
                 down button during the boot process. You can either boot it with the power button
                 or by plugging it in as required in the next section.</p>
+
+                <p>This step is not complete until your device displays a red warning triangle
+                and the words "Fastboot Mode".  You must not press the device's power button
+                to activate the "Start" menu item, because the device must remain paused in
+                Fastboot mode for the <code>fastboot</code> command to connect to it.</p>
             </section>
 
             <section id="connecting-device">

--- a/static/install/web.html
+++ b/static/install/web.html
@@ -225,6 +225,11 @@
                 <p>Alternatively, turn off the device, then boot it up while holding the volume
                 down button during the boot process. You can either boot it with the power button
                 or by plugging it in as required in the next section.</p>
+
+                <p>This step is not complete until your device displays a red warning triangle
+                and the words "Fastboot Mode".  You must not press the device's power button
+                to activate the "Start" menu item, because the device must remain paused in
+                Fastboot mode for the installer to connect to it.</p>
             </section>
 
             <section id="connecting-device">


### PR DESCRIPTION
The discussion forum has seen quite a few instances of users who think they have entered fastboot but haven't, or who enter fastboot but accidentally leave it by invoking the "Start" action (because they wish to start the installation process and "Start" looks attractive).  Here are two examples of users indicating that explicit directions would be helpful:
* https://discuss.grapheneos.org/d/10515-installation-error-unlocking-bootloader/29
* https://discuss.grapheneos.org/d/10515-installation-error-unlocking-bootloader/26

This commit spells out how a user can be sure that fastboot is active and also that it is important to **_not_** invoke the "Start" action.