### PR TITLE
add HEK Service-App to attestation compatibility guide

### DIFF
--- a/static/articles/attestation-compatibility-guide.html
+++ b/static/articles/attestation-compatibility-guide.html
@@ -151,6 +151,7 @@
                     <li><a href="https://play.google.com/store/apps/details?id=com.revolut.business">Revolut Business</a></li>
                     <li><a href="https://play.google.com/store/apps/details?id=com.mcdonalds.mobileapp">McDonald's</a> (International app used for many but not all countries not including the US)</li>
                     <li><a href="https://play.google.com/store/apps/details?id=de.tk.tkapp">TK-App</a></li>
+                    <li><a href="https://play.google.com/store/apps/details?id=de.hek.serviceapp">HEK Service-App</a></li>
                 </ul>
 
                 <p>In addition to leaving feedback for these apps on the Play Store, file support


### PR DESCRIPTION
Recently I learned that the HEK service app from a German health insurance company also seems to use Play Integrity API and therefore cannot be used on GrapheneOS, so I would like to add it to the list.