### PR TITLE
Generalized install info related to fwupd bug on Debian-based distros

### DIFF
--- a/static/install/cli.html
+++ b/static/install/cli.html
@@ -308,13 +308,18 @@ Installed as /home/username/platform-tools/fastboot</pre>
             <section id="working-around-fwupd-bug-on-linux-distributions">
                 <h2><a href="#working-around-fwupd-bug-on-linux-distributions">Working around fwupd bug on Linux distributions</a></h2>
 
-                <p>Debian stable and Ubuntu have an outdated fwupd package with a bug breaking
-                connecting to Android's bootloader interface (fastboot) while fwupd is running
-                since it tries to connect to arbitrary devices. This section can be skipped on
-                Arch Linux and other distributions with fwupd 1.9.10 or later since we reported
-                the bug and it was fixed. This never impacted Android or ChromeOS.</p>
+                <p>Some Debian, Ubuntu, and derivative distributions have an outdated fwupd package 
+                with a bug breaking connecting to Android's bootloader interface (fastboot) while 
+                fwupd is running since it tries to connect to arbitrary devices. This section can 
+                be skipped on Arch Linux and other distributions with fwupd 1.9.10 or later since 
+                we reported the bug and it was fixed. This never impacted Android or ChromeOS.</p>
 
-                <p>You can stop fwupd with the following command:</p>
+                <p>Check your fwupd version with the following command:</p>
+
+                <pre>apt-cache policy fwupd</pre>
+
+                <p>If you have a fwupd version earlier than 1.9.10, you can stop fwupd with the 
+                following command:</p>
 
                 <pre>sudo systemctl stop fwupd.service</pre>
 

--- a/static/install/web.html
+++ b/static/install/web.html
@@ -54,7 +54,7 @@
                     <li><a href="#prerequisites">Prerequisites</a></li>
                     <li><a href="#enabling-oem-unlocking">Enabling OEM unlocking</a></li>
                     <li><a href="#flashing-as-non-root">Flashing as non-root</a></li>
-                    <li><a href="#working-around--bug-on-linux-distributions">Working around  bug on Linux distributions</a></li>
+                    <li><a href="#working-around-fwupd-bug-on-linux-distributions">Working around  bug on Linux distributions</a></li>
                     <li><a href="#booting-into-the-bootloader-interface">Booting into the bootloader interface</a></li>
                     <li><a href="#connecting-device">Connecting the device</a></li>
                     <li><a href="#unlocking-the-bootloader">Unlocking the bootloader</a></li>

--- a/static/install/web.html
+++ b/static/install/web.html
@@ -54,7 +54,7 @@
                     <li><a href="#prerequisites">Prerequisites</a></li>
                     <li><a href="#enabling-oem-unlocking">Enabling OEM unlocking</a></li>
                     <li><a href="#flashing-as-non-root">Flashing as non-root</a></li>
-                    <li><a href="#working-around-fwupd-bug-on-linux-distributions">Working around fwupd bug on Linux distributions</a></li>
+                    <li><a href="#working-around--bug-on-linux-distributions">Working around  bug on Linux distributions</a></li>
                     <li><a href="#booting-into-the-bootloader-interface">Booting into the bootloader interface</a></li>
                     <li><a href="#connecting-device">Connecting the device</a></li>
                     <li><a href="#unlocking-the-bootloader">Unlocking the bootloader</a></li>
@@ -200,13 +200,18 @@
             <section id="working-around-fwupd-bug-on-linux-distributions">
                 <h2><a href="#working-around-fwupd-bug-on-linux-distributions">Working around fwupd bug on Linux distributions</a></h2>
 
-                <p>Debian stable and Ubuntu have an outdated fwupd package with a bug breaking
-                connecting to Android's bootloader interface (fastboot) while fwupd is running
-                since it tries to connect to arbitrary devices. This section can be skipped on
-                Arch Linux and other distributions with fwupd 1.9.10 or later since we reported
-                the bug and it was fixed. This never impacted Android or ChromeOS.</p>
+                <p>Some Debian, Ubuntu, and derivative distributions have an outdated fwupd package 
+                with a bug breaking connecting to Android's bootloader interface (fastboot) while 
+                fwupd is running since it tries to connect to arbitrary devices. This section can 
+                be skipped on Arch Linux and other distributions with fwupd 1.9.10 or later since 
+                we reported the bug and it was fixed. This never impacted Android or ChromeOS.</p>
 
-                <p>You can stop fwupd with the following command:</p>
+                <p>Check your fwupd version with the following command:</p>
+
+                <pre>apt-cache policy fwupd</pre>
+
+                <p>If you have a fwupd version earlier than 1.9.10, you can stop fwupd with the 
+                following command:</p>
 
                 <pre>sudo systemctl stop fwupd.service</pre>
 


### PR DESCRIPTION
Updated Web Install info related to issue #1088 about the fwupd bug in Debian and some Ubuntu versions.  This avoids unnecessarily stopping fwupd on releases that don't have the bug, and it keeps the guide generalized for applicability to other Debian- and Ubuntu-derived distros.  It won't need to be revisited until years from now when Debian and Ubuntu entirely drop support for the current releases that use the outdated fwupd version.