### PR TITLE
add "DAK App" to list of apps banning GrapheneOS

### DIFF
--- a/static/articles/attestation-compatibility-guide.html
+++ b/static/articles/attestation-compatibility-guide.html
@@ -151,6 +151,7 @@
                     <li><a href="https://play.google.com/store/apps/details?id=com.revolut.business">Revolut Business</a></li>
                     <li><a href="https://play.google.com/store/apps/details?id=com.mcdonalds.mobileapp">McDonald's</a> (International app used for many but not all countries not including the US)</li>
                     <li><a href="https://play.google.com/store/apps/details?id=de.tk.tkapp">TK-App</a></li>
+                    <li><a href="https://play.google.com/store/apps/details?id=de.dak.dak_app">DAK App</a></li>
                 </ul>
 
                 <p>In addition to leaving feedback for these apps on the Play Store, file support


### PR DESCRIPTION
The [DAK App](https://play.google.com/store/apps/details?id=de.dak.dak_app) from a German health insurance company also seems to use the Play Integrity API and therefore cannot be used on GrapheneOS, so I would like to add it to the list.

The app immediately blocks everything when it starts:
[DAK App log 432c9baa12f2.txt](https://github.com/user-attachments/files/18306203/DAK.App.log.432c9baa12f2.txt)
![Screenshot](https://github.com/user-attachments/assets/5fad8669-a327-4c1f-8dd1-33f3a49ad1c4)


