### PR TITLE
web installer await `BlobStore.saveFile` transaction

### DIFF
--- a/static/js/web-install.js
+++ b/static/js/web-install.js
@@ -113,10 +113,12 @@ class BlobStore {
     }
 
     async saveFile(name, blob) {
-        this.db.transaction(["files"], "readwrite").objectStore("files").add({
-            name: name,
-            blob: blob,
-        });
+        await this._wrapReq(
+            this.db.transaction(["files"], "readwrite").objectStore("files").add({
+                name: name,
+                blob: blob,
+            })
+        );
     }
 
     async loadFile(name) {


### PR DESCRIPTION
applies the suggested fix from https://github.com/GrapheneOS/grapheneos.org/issues/1132

the async `BlobStore.saveFile` function now awaits the actual transaction outcome, instead of performing no async operation and returning while the transaction is still pending.

this means:
- the download function actually awaits the completion of the save transaction, as seems intended
- failures thrown by the save transaction are no longer unhandled