### PR TITLE
Add Swissquote to list of apps banning GrapheneOS via Play Integrity API

### DIFF
--- a/static/articles/attestation-compatibility-guide.html
+++ b/static/articles/attestation-compatibility-guide.html
@@ -152,6 +152,7 @@
                     <li><a href="https://play.google.com/store/apps/details?id=com.yuh">Yuh</a></li>
                     <li><a href="https://play.google.com/store/apps/details?id=de.tk.tkapp">TK-App</a></li>
                     <li><a href="https://play.google.com/store/apps/details?id=it.pagopa.io.app">IO</a> (Italian government app which uses it for the digital wallet feature)</li>
+                    <li><a href="https://play.google.com/store/apps/details?id=com.swissquote.android">Swissquote</a></li>
                 </ul>
 
                 <p>In addition to leaving feedback for these apps on the Play Store, file support


### PR DESCRIPTION
Info here: https://github.com/PrivSec-dev/banking-apps-compat-report/issues/471

The same company's "Yuh" product seems to be making an effort to support GrapheneOS. Hopefully Swissquote can also add support for GrapheneOS in the future.