### PR TITLE
Remove Yuh from list of apps banning GrapheneOS

### DIFF
--- a/static/articles/attestation-compatibility-guide.html
+++ b/static/articles/attestation-compatibility-guide.html
@@ -150,7 +150,6 @@
                     <li><a href="https://play.google.com/store/apps/details?id=com.mcdonalds.mobileapp">McDonald's</a> (International app used for many but not all countries not including the US)</li>
                     <li><a href="https://play.google.com/store/apps/details?id=com.swissquote.android">Swissquote</a></li>
                     <li><a href="https://play.google.com/store/apps/details?id=com.swisssign.swissid.mobile">SwissID</a></li>
-                    <li><a href="https://play.google.com/store/apps/details?id=com.yuh">Yuh</a></li>
                     <li><a href="https://play.google.com/store/apps/details?id=de.tk.tkapp">TK-App</a></li>
                     <li><a href="https://play.google.com/store/apps/details?id=it.pagopa.io.app">IO</a> (Italian government app which uses it for the digital wallet feature)</li>
                 </ul>


### PR DESCRIPTION
https://github.com/PrivSec-dev/banking-apps-compat-report/issues/509#issuecomment-2757531231

Yuh is going to be using Play Integrity API but whitelisting GrapheneOS.