### PR TITLE
faq page: fix clipboard settings path

### DIFF
--- a/static/faq.html
+++ b/static/faq.html
@@ -665,7 +665,7 @@
                     <p>As of Android 12, the user is notified when an app reads clipboard content
                     which was set by a different app. This notice is enabled by default and can be
                     toggled under <b>Settings&#160;<span aria-label="and then">></span>
-                    Security &amp; privacy&#160;<span aria-label="and then">></span> Privacy&#160;<span
+                    Security &amp; privacy&#160;<span aria-label="and then">></span> Privacy controls&#160;<span
                     aria-label="and then">></span> Show clipboard access</b>.</p>
                 </article>
 


### PR DESCRIPTION
Updated to match current setting name.