### PR TITLE
Opt-into edge-to-edge by default

### DIFF
--- a/static/404.html
+++ b/static/404.html
@@ -7,7 +7,7 @@
         <meta name="theme-color" content="#212121"/>
         <meta name="color-scheme" content="dark light"/>
         <meta name="msapplication-TileColor" content="#ffffff"/>
-        <meta name="viewport" content="width=device-width, initial-scale=1"/>
+        <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover"/>
         <meta name="twitter:site" content="@GrapheneOS"/>
         <meta name="twitter:creator" content="@GrapheneOS"/>
         <meta property="og:title" content="Page not found"/>

--- a/static/build.html
+++ b/static/build.html
@@ -7,7 +7,7 @@
         <meta name="theme-color" content="#212121"/>
         <meta name="color-scheme" content="dark light"/>
         <meta name="msapplication-TileColor" content="#ffffff"/>
-        <meta name="viewport" content="width=device-width, initial-scale=1"/>
+        <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover"/>
         <meta name="twitter:site" content="@GrapheneOS"/>
         <meta name="twitter:creator" content="@GrapheneOS"/>
         <meta property="og:title" content="GrapheneOS build documentation"/>

--- a/static/camera-privacy-policy.html
+++ b/static/camera-privacy-policy.html
@@ -7,7 +7,7 @@
         <meta name="theme-color" content="#212121"/>
         <meta name="color-scheme" content="dark light"/>
         <meta name="msapplication-TileColor" content="#ffffff"/>
-        <meta name="viewport" content="width=device-width, initial-scale=1"/>
+        <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover"/>
         <meta name="twitter:site" content="@GrapheneOS"/>
         <meta name="twitter:creator" content="@GrapheneOS"/>
         <meta property="og:title" content="Camera privacy policy"/>

--- a/static/contact.html
+++ b/static/contact.html
@@ -7,7 +7,7 @@
         <meta name="theme-color" content="#212121"/>
         <meta name="color-scheme" content="dark light"/>
         <meta name="msapplication-TileColor" content="#ffffff"/>
-        <meta name="viewport" content="width=device-width, initial-scale=1"/>
+        <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover"/>
         <meta name="twitter:site" content="@GrapheneOS"/>
         <meta name="twitter:creator" content="@GrapheneOS"/>
         <meta property="og:title" content="GrapheneOS contact information"/>

--- a/static/donate.html
+++ b/static/donate.html
@@ -7,7 +7,7 @@
         <meta name="theme-color" content="#212121"/>
         <meta name="color-scheme" content="dark light"/>
         <meta name="msapplication-TileColor" content="#ffffff"/>
-        <meta name="viewport" content="width=device-width, initial-scale=1"/>
+        <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover"/>
         <meta name="twitter:site" content="@GrapheneOS"/>
         <meta name="twitter:creator" content="@GrapheneOS"/>
         <meta property="og:title" content="GrapheneOS donations"/>

--- a/static/faq.html
+++ b/static/faq.html
@@ -7,7 +7,7 @@
         <meta name="theme-color" content="#212121"/>
         <meta name="color-scheme" content="dark light"/>
         <meta name="msapplication-TileColor" content="#ffffff"/>
-        <meta name="viewport" content="width=device-width, initial-scale=1"/>
+        <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover"/>
         <meta name="twitter:site" content="@GrapheneOS"/>
         <meta name="twitter:creator" content="@GrapheneOS"/>
         <meta property="og:title" content="GrapheneOS Frequently Asked Questions"/>

--- a/static/features.html
+++ b/static/features.html
@@ -7,7 +7,7 @@
         <meta name="theme-color" content="#212121"/>
         <meta name="color-scheme" content="dark light"/>
         <meta name="msapplication-TileColor" content="#ffffff"/>
-        <meta name="viewport" content="width=device-width, initial-scale=1"/>
+        <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover"/>
         <meta name="twitter:site" content="@GrapheneOS"/>
         <meta name="twitter:creator" content="@GrapheneOS"/>
         <meta property="og:title" content="GrapheneOS features overview"/>

--- a/static/hiring.html
+++ b/static/hiring.html
@@ -7,7 +7,7 @@
         <meta name="theme-color" content="#212121"/>
         <meta name="color-scheme" content="dark light"/>
         <meta name="msapplication-TileColor" content="#ffffff"/>
-        <meta name="viewport" content="width=device-width, initial-scale=1"/>
+        <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover"/>
         <meta name="twitter:site" content="@GrapheneOS"/>
         <meta name="twitter:creator" content="@GrapheneOS"/>
         <meta property="og:title" content="GrapheneOS Hiring"/>

--- a/static/index.html
+++ b/static/index.html
@@ -7,7 +7,7 @@
         <meta name="theme-color" content="#212121"/>
         <meta name="color-scheme" content="dark light"/>
         <meta name="msapplication-TileColor" content="#ffffff"/>
-        <meta name="viewport" content="width=device-width, initial-scale=1"/>
+        <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover"/>
         <meta name="twitter:site" content="@GrapheneOS"/>
         <meta name="twitter:creator" content="@GrapheneOS"/>
         <meta property="og:title" content="GrapheneOS: the private and secure mobile OS"/>

--- a/static/pdfviewer-privacy-policy.html
+++ b/static/pdfviewer-privacy-policy.html
@@ -7,7 +7,7 @@
         <meta name="theme-color" content="#212121"/>
         <meta name="color-scheme" content="dark light"/>
         <meta name="msapplication-TileColor" content="#ffffff"/>
-        <meta name="viewport" content="width=device-width, initial-scale=1"/>
+        <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover"/>
         <meta name="twitter:site" content="@GrapheneOS"/>
         <meta name="twitter:creator" content="@GrapheneOS"/>
         <meta property="og:title" content="PDF Viewer privacy policy"/>

--- a/static/releases.html
+++ b/static/releases.html
@@ -7,7 +7,7 @@
         <meta name="theme-color" content="#212121"/>
         <meta name="color-scheme" content="dark light"/>
         <meta name="msapplication-TileColor" content="#ffffff"/>
-        <meta name="viewport" content="width=device-width, initial-scale=1"/>
+        <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover"/>
         <meta name="twitter:site" content="@GrapheneOS"/>
         <meta name="twitter:creator" content="@GrapheneOS"/>
         <meta property="og:title" content="GrapheneOS releases"/>

--- a/static/source.html
+++ b/static/source.html
@@ -7,7 +7,7 @@
         <meta name="theme-color" content="#212121"/>
         <meta name="color-scheme" content="dark light"/>
         <meta name="msapplication-TileColor" content="#ffffff"/>
-        <meta name="viewport" content="width=device-width, initial-scale=1"/>
+        <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover"/>
         <meta name="twitter:site" content="@GrapheneOS"/>
         <meta name="twitter:creator" content="@GrapheneOS"/>
         <meta property="og:title" content="GrapheneOS source code"/>

--- a/static/usage.html
+++ b/static/usage.html
@@ -7,7 +7,7 @@
         <meta name="theme-color" content="#212121"/>
         <meta name="color-scheme" content="dark light"/>
         <meta name="msapplication-TileColor" content="#ffffff"/>
-        <meta name="viewport" content="width=device-width, initial-scale=1"/>
+        <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover"/>
         <meta name="twitter:site" content="@GrapheneOS"/>
         <meta name="twitter:creator" content="@GrapheneOS"/>
         <meta property="og:title" content="GrapheneOS usage guide"/>


### PR DESCRIPTION
Chromium already supports dynamic edge-to-edge viewports. This change opts-in by default, making the gesture navigation bar (chin) invisible without needing scroll interaction.

No other changes were necessary, as no content relied on specific viewport insets.

Command used:

```
sed -i 's/<meta name="viewport" content="width=device-width, initial-scale=1"\/>/<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover"\/>/g' **/*.html
```