### PR TITLE
add note about using a Pixel 6a as install platform

### DIFF
--- a/static/install/web.html
+++ b/static/install/web.html
@@ -85,7 +85,9 @@
 
                 <p>You need a computer for running the web installer with at least 2GB of free
                 memory available and 32GB of free storage space. The web installer can be run on an
-                Android phone or tablet, unlike the command-line installation.</p>
+                Android phone or tablet, unlike the command-line installation. It is a known issue,
+                however, that the Pixel 6a cannot be used for flashing. Flashing GrapheneOS onto
+                a Pixel 6a works, but using a Pixel 6a to flash another supported device does not.</p>
 
                 <p>You need a USB cable for attaching the device to the computer performing the
                 installation. Whenever possible, use the high quality standards compliant USB-C


### PR DESCRIPTION
Proposed change: Add note to web installer instructions about the Pixel 6a not working as an install platform (computer used to flash a supported device).

Context: Pixel 6a can't be used to flash a support device. Web installer does not find the device. This was tested by pull requester on a Pixel 6a running GrapheneOS [2025071900](https://grapheneos.org/releases#2025071900). The OS was configured with default settings, the browser as well. All of the web installer instructions were followed. After seeking support on the official support channels, it was confirmed by the community that this is a known Pixel 6a issue.

Reasoning: Useful to add to the website given that the Pixel 6a is a likely candidate to be used as an install platform and because it is unclear why the install fails without asking on the community chat rooms / fora. The Pixel 6a is a popular device for running GrapheneOS but is over half of its support time already. It is likely that this device will be used a lot more for flashing in the future when GrapheneOS users upgrade their devices, especially because it's often encouraged to use an Android device as an install platform because it's normally the most reliable.