### PR TITLE
Improve error handling in the web installer

### DIFF
--- a/static/install/web.html
+++ b/static/install/web.html
@@ -288,6 +288,9 @@
 
                 <p>Press the button below to start the download:</p>
 
+                <p><strong id="quota-warning-text" class="warning-text" hidden="hidden">Warning: browser
+                is reporting a low storage quota, there might not be enough space for the image</strong></p>
+
                 <button id="download-release-button" disabled="">Download release</button>
 
                 <p id="download-release-status-container" hidden="hidden">

--- a/static/js/web-install.js
+++ b/static/js/web-install.js
@@ -491,6 +491,16 @@ if ("usb" in navigator) {
     addButtonHook(Buttons.FLASH_RELEASE, flashRelease);
     addButtonHook(Buttons.LOCK_BOOTLOADER, lockBootloader);
     addButtonHook(Buttons.REMOVE_CUSTOM_KEY, eraseNonStockKey);
+
+    if (navigator.storage && navigator.storage.estimate) {
+        navigator.storage.estimate().then(estimate => {
+            // Currently factory images are ~1700MiB
+            // Show a warning if the estimated space is below 1800MiB
+            if (estimate.quota !== 0 && estimate.quota < 1024*1024*1800) {
+                document.getElementById("quota-warning-text").hidden = false;
+            }
+        });
+    }
 } else {
     console.log("WebUSB unavailable");
 }

--- a/static/js/web-install.js
+++ b/static/js/web-install.js
@@ -59,13 +59,19 @@ function fetchBlobWithProgress(url, onProgress) {
 
     return new Promise((resolve, reject) => {
         xhr.onload = () => {
-            resolve(xhr.response);
+            if (xhr.status !== 200) {
+                reject(`${xhr.status} ${xhr.statusText}`);
+            } else {
+                resolve(xhr.response);
+            }
         };
         xhr.onprogress = (event) => {
             onProgress(event.loaded / event.total);
         };
         xhr.onerror = () => {
-            reject(`${xhr.status} ${xhr.statusText}`);
+            // onerror is called on network errors
+            // status and statusText are populated with default values
+            reject("Network request failed");
         };
     });
 }

--- a/static/js/web-install.js
+++ b/static/js/web-install.js
@@ -396,7 +396,15 @@ function addButtonHook(id, callback) {
                 statusCallback(finalStatus);
             }
         } catch (error) {
-            statusCallback(`Error: ${error.message}`);
+            let errorMessage;
+            if (typeof(error) === "object" && error.message != null && error.message !== "") {
+                errorMessage = error.message;
+            } else {
+                // sometimes non-error objects are thrown
+                // display its string representation instead of "Error: undefined"
+                errorMessage = error.toString();
+            }
+            statusCallback(`Error: ${errorMessage}`);
             statusField.className = "error-text";
             await releaseWakeLock();
             // Rethrow the error so it shows up in the console

--- a/static/main.css
+++ b/static/main.css
@@ -259,6 +259,11 @@ footer a, footer a:visited {
     list-style-type: none;
 }
 
+.warning-text {
+    /* Material 3 reference pallete: Yellow 30 */
+    color: #6f3a01;
+}
+
 .error-text {
     /* Baseline Material error color */
     color: #b00020;
@@ -487,6 +492,11 @@ details[open] summary {
 
     footer img {
         filter: invert(87%);
+    }
+
+    .warning-text {
+        /* Material 3 reference pallete: Yellow 80 */
+        color: #fcbd00;
     }
 
     .error-text {


### PR DESCRIPTION
Some bugs in the web installer were causing errors to be handled badly:
1. Sometimes non-error object were thrown, which resulted in "Error: undefined" being displayed, as the message was formatted with `Error: ${error.message}`.
2. XMLHttpRequest code assumed that non-200 status codes would result in onerror being called, but that's not the case. I added an explicit check for status codes in onload and replaced the message in onerror with a generic "Network request failed".
3. Saving files in IndexedDB can fail because of low storage quotas, but this condition wasn't being detected, because the error is reported on the IDBTransaction's 'abort' event handler, while handlers were only registered on the IDBRequest object.

Additionally, I added a preemptive warning when the browser estimates a storage quota below 1800MiB, which is around 100MiB more than the average factory image size.

Screenshot showing the quota handling improvements:
<img width="788" height="303" alt="25a78177-cf20-4ecf-91fe-b226670d03c8" src="https://github.com/user-attachments/assets/95c08517-0f7a-4b75-881d-6330115990f1" />