### PR TITLE
Remove outdated information about WebView and JS JIT toggle

### DIFF
--- a/static/features.html
+++ b/static/features.html
@@ -1142,10 +1142,10 @@
                         Vanadium)</li>
                     </ul>
 
-                    <p>Configurable features such as JS JIT disabling and content filtering are
-                    currently exclusive to the Vanadium browser. Vanadium WebView is currently
-                    excluded from these changes until it has an app setting configuration menu
-                    similar to the standard site setting configuration menu.</p>
+                    <p>Configurable features such as content filtering are currently exclusive
+                    to the Vanadium browser. Vanadium WebView is currently excluded from these
+                    changes until it has an app setting configuration menu similar to the standard
+                    site setting configuration menu.</p>
 
                     <p>Extension support isn't planned due to being at odds with site isolation and
                     anti-fingerprinting. We plan to implement more features as part of the browser


### PR DESCRIPTION
EDIT: superseded by https://github.com/GrapheneOS/grapheneos.org/commit/d54052b49af71bcb04cb41f92f65e30b455aa358

Removing outdated information from:

>Configurable features such _**as JS JIT disabling**_ and content filtering are currently exclusive to the Vanadium browser. Vanadium WebView is currently excluded from these changes until it has an app setting configuration menu similar to the standard site setting configuration menu.

JS JIT disabling is available for WebView via a per-app restriction toggle since 2024082200.

https://grapheneos.org/releases#2024082200