### PR TITLE
web installation: Make `fwupd` workaround instructions more portable

### DIFF
--- a/static/install/web.html
+++ b/static/install/web.html
@@ -216,7 +216,7 @@
 
                 <p>You can stop fwupd with the following command:</p>
 
-                <pre>sudo systemctl stop fwupd.service</pre>
+                <pre>sudo fwupdmgr quit</pre>
 
                 <p>This doesn't disable the service and it will start again on reboot.</p>
             </section>


### PR DESCRIPTION
The previous command for disabling the `fwupd` daemon only works on distributions using systemd. I'm using [Chimera Linux](https://chimera-linux.org/), which uses the featureful alternative `dinit`. Thankfully, the `fwupdmgr` tool packaged with `fwupd` has a `quit` command that uses dbus to tell the daemon to quit, without making any assumptions about what init system is being used.

This should not be merged without testing that this command works properly on all Linux distributions officially supported by the web installation tool. It's possible that some distributions have systemd configured to automatically restart the daemon if it quits.