### PR TITLE
Add mobile menu toggle button and responsive styles

### DIFF
--- a/static/main.css
+++ b/static/main.css
@@ -530,3 +530,60 @@ details[open] summary {
         color: #dae2f9 /* on secondary container */;
     }
 }
+
+#menu-toggle, label[for="menu-toggle"] {
+    display: none;
+}
+
+@media (max-width: 768px) {
+    label[for="menu-toggle"] {
+        position: absolute;
+        right: 0%;
+        top: 0%;
+        height: 3rem;
+        width: 3rem;
+        margin: 0.4rem;
+        display: block;
+        cursor: pointer;
+    }
+
+    #site-menu ul {
+        display: block;
+        max-height: 3.8rem;
+        height: 100%;
+        transition: max-height 0.3s ease-in-out;
+        overflow: hidden;
+    }
+
+    #site-menu:has(#menu-toggle:checked) ul {
+        max-height: 800px;
+    }
+
+    #site-menu ul li a {
+        width: 100%;
+    }
+
+    #site-menu:has(#menu-toggle:checked)label[for="menu-toggle"]::before {
+        transform: translateY(0.85rem) rotate(135deg);
+    }
+
+    #site-menu:has(#menu-toggle:checked) label[for="menu-toggle"]::after {
+        transform: translateY(-0.85rem) rotate(-135deg);
+    }
+
+    #site-menu:has(#menu-toggle:checked) label[for="menu-toggle"] span {
+        transform: scale(0);
+    }
+
+    label[for="menu-toggle"]::after,
+    label[for="menu-toggle"]::before,
+    label[for="menu-toggle"] span {
+        background-color: #64b5f6; /* blue300 */
+        border-radius: 3px;
+        content: "";
+        display: block;
+        height: 0.3rem;
+        margin: 0.55rem 0;
+        transition: all 0.2s ease-in-out;
+    }
+}

--- a/templates/header.html
+++ b/templates/header.html
@@ -1,5 +1,9 @@
 <header>
     <nav id="site-menu">
+        <label for="menu-toggle">
+            <span></span>
+        </label>
+        <input type="checkbox" id="menu-toggle" />
         <ul>
             <li {% if current_page == "/" %}aria-current="page"{% endif %}><a href="/"><img src="[[path|/mask-icon.svg]]" alt=""/>GrapheneOS</a></li>
             <li {% if current_page == "features" %}aria-current="page"{% endif %}><a href="/features">Features</a></li>


### PR DESCRIPTION
# New animated mobile menu toggle button (without JavaScript)

This pull request introduces a responsive mobile navigation menu to the site header, improving usability on smaller screens. The main changes add a hamburger-style toggle button and update the CSS to support mobile-friendly menu behavior.

# Preview

<table>
<tr>
<td><br /><img width="826" height="1586" alt="dark" src="https://github.com/user-attachments/assets/559215db-5899-46ab-a422-163aa2debdbd" /><br /><br /></td><td><br /><img width="826" height="1586" alt="extended-dark" src="https://github.com/user-attachments/assets/d4e4b082-6e76-4ebb-ba74-68991ec6807f" /><br /><br /></td></tr>

<tr><th>Homepage darkmode</th><th>Homepage darkmode extended</th></tr>

<tr>
<td>
<br /><img width="826" height="1586" alt="light" src="https://github.com/user-attachments/assets/c51edc22-c2cb-47e2-9b2c-9f590e1b4f9c" /><br /><br /></td><td><br /><img width="826" height="1586" alt="extended-light" src="https://github.com/user-attachments/assets/83ac6d46-0fa8-45c0-b774-6300f1497c93" /><br /><br /></td>
</tr>
<tr><th>Homepage lightmode</th><th>Homepage lightmode extended</th></tr>

</table>



**Mobile navigation improvements:**

* Added a toggle button and corresponding checkbox (`label[for="menu-toggle"]` and `#menu-toggle`) to the navigation bar in `header.html` for mobile menu activation.
* Updated `main.css` with new styles and media queries to hide the menu toggle on desktop, show it on screens smaller than 768px, and animate the menu expansion/collapse and hamburger icon transitions.