### PR TITLE
specify the classic version of yarn

### DIFF
--- a/static/build.html
+++ b/static/build.html
@@ -266,7 +266,7 @@ source ~/.bashrc</pre>
 
                     <ul>
                         <li>Node.js 24 LTS</li>
-                        <li>yarn</li>
+                        <li>yarn (classic)</li>
                     </ul>
 
                     <p>Additional Vanadium (Chromium) build dependencies not provided by the source tree:</p>


### PR DESCRIPTION
Yarn Modern (v2+) formats its lockfile differently, and would mutate the lockfile of adevtool. This issue became apparent while supporting a user in the developement room.

Most distributions package Yarn Classic anyway.