### PR TITLE
Add GOV.UK One Login to Play Integrity API list

### DIFF
--- a/static/articles/attestation-compatibility-guide.html
+++ b/static/articles/attestation-compatibility-guide.html
@@ -152,6 +152,11 @@
                 <ul>
                     <li><a href="https://play.google.com/store/apps/details?id=au.gov.mygov.mygovapp" rel="nofollow">myGov</a> (Australian government app)</li>
                     <li><a href="https://play.google.com/store/apps/details?id=br.gov.meugovbr" rel="nofollow">gov.br</a> (Brazilian government app)</li>
+                    <li>
+                        <a href="https://play.google.com/store/apps/details?id=uk.gov.onelogin">GOV.UK One Login</a>
+                        (UK government app)
+                        <a href="https://github.com/alphagov/govuk-mobile-android-app/issues/342">(GitHub issue)</a>
+                    </li>
                     <li><a href="https://play.google.com/store/apps/details?id=ch.ticketcorner.mobile.app.Android" rel="nofollow">Ticketcorner</a></li>
                     <li><a href="https://play.google.com/store/apps/details?id=com.authy.authy" rel="nofollow">Authy</a></li>
                     <li><a href="https://play.google.com/store/apps/details?id=com.chyrpe.chyrpe" rel="nofollow">Chyrpe Dating</a></li>

--- a/static/articles/attestation-compatibility-guide.html
+++ b/static/articles/attestation-compatibility-guide.html
@@ -153,9 +153,9 @@
                     <li><a href="https://play.google.com/store/apps/details?id=au.gov.mygov.mygovapp" rel="nofollow">myGov</a> (Australian government app)</li>
                     <li><a href="https://play.google.com/store/apps/details?id=br.gov.meugovbr" rel="nofollow">gov.br</a> (Brazilian government app)</li>
                     <li>
-                        <a href="https://play.google.com/store/apps/details?id=uk.gov.onelogin">GOV.UK One Login</a>
+                        <a href="https://play.google.com/store/apps/details?id=uk.gov.onelogin" rel="nofollow">GOV.UK One Login</a>
                         (UK government app)
-                        <a href="https://github.com/alphagov/govuk-mobile-android-app/issues/342">(GitHub issue)</a>
+                        <a href="https://github.com/alphagov/govuk-mobile-android-app/issues/342" rel="nofollow">(GitHub issue)</a>
                     </li>
                     <li><a href="https://play.google.com/store/apps/details?id=ch.ticketcorner.mobile.app.Android" rel="nofollow">Ticketcorner</a></li>
                     <li><a href="https://play.google.com/store/apps/details?id=com.authy.authy" rel="nofollow">Authy</a></li>


### PR DESCRIPTION
The UK Government's new One Login app is being rolled out for [some services](https://home.account.gov.uk/services-using-one-login) this year, providing identity verification and digital wallets (e.g. [digital driving licences](https://www.gov.uk/wallet).)

Alongside the Play Store URL, I've also added a link to [a relevant issue](https://github.com/alphagov/govuk-mobile-android-app/issues/342) on the 
Government Digital Service's GitHub repo.

https://github.com/user-attachments/assets/e314dd1e-92c1-4805-8015-e477c26c063f

