### PR TITLE
Update build instructions to warn about insufficient space in /tmp

### DIFF
--- a/static/build.html
+++ b/static/build.html
@@ -601,6 +601,13 @@ cd ../..</pre>
 
                     <pre>script/generate-release.sh tegu <var>BUILD_NUMBER</var></pre>
 
+                    <p>If this results in an error similar to
+                    <code>Disk quota exceeded while populating file system</code>,
+                    the first thing to check is whether <code>/tmp</code> has enough space
+                    (more than 15GB).  The installation instructions include information about
+                    <a href="/install/cli.html#TMPDIR">using a different directory for temporary
+                    files</a>.</p>
+
                     <p>The factory images and update package will be in
                     <code>releases/<var>BUILD_NUMBER</var>/release-tegu-<var>BUILD_NUMBER</var></code>.
                     The update zip performs a full OS installation so it can be used to update from

--- a/static/install/cli.html
+++ b/static/install/cli.html
@@ -492,12 +492,13 @@ curl -O https://releases.grapheneos.org/<var>DEVICE_NAME</var>-install-<var>VERS
                     went wrong. Please provide this information when asking for help on the
                     <a href="/contact#community">GrapheneOS chat room</a>.</p>
 
-                    <p>A common issue on Linux distributions is that they mount the default temporary file
-                    directory <code>/tmp</code> as tmpfs which results in it being backed by memory and
-                    swap rather than persistent storage. By default, the size is 50% of the available
-                    virtual memory. This is often not enough for the flashing process, especially since
-                    <code>/tmp</code> is shared between applications and users. To use a different
-                    temporary directory if your <code>/tmp</code> doesn't have enough space available:</p>
+                    <p id="TMPDIR">A common issue on Linux distributions is that they mount the
+                    default temporary file directory <code>/tmp</code> as tmpfs which results
+                    in it being backed by memory and swap rather than persistent storage. By default,
+                    the size is 50% of the available virtual memory. This is often not enough for
+                    the flashing process, especially since <code>/tmp</code> is shared between
+                    applications and users. To use a different temporary directory if your
+                    <code>/tmp</code> doesn't have enough space available:</p>
 
                     <pre>mkdir tmp &amp;&amp; TMPDIR="$PWD/tmp" ./flash-all.sh</pre>
                 </section>


### PR DESCRIPTION
I validated this by setting TMPDIR to /var/tmp and observing space usage in /tmp and /var/tmp while running ```generate-release.sh``` for tokay.  Usage in /var/tmp went up by 14 gigabytes as expected while usage in /tmp remained under 3 megabytes throughout.

Please feel free to let me know if you would like me to make changes.

Motivation: [forum thread #28299](https://discuss.grapheneos.org/d/28299-cannot-generate-release-for-tokay-qpr1-due-to-disk-quota).