### PR TITLE
remove aria-label on <span>

### DIFF
--- a/static/faq.html
+++ b/static/faq.html
@@ -636,9 +636,8 @@
 
                     <p>As of Android 12, the user is notified when an app reads clipboard content
                     which was set by a different app. This notice is enabled by default and can be
-                    toggled under <b>Settings&#160;<span aria-label="and then">></span>
-                    Security &amp; privacy&#160;<span aria-label="and then">></span> Privacy controls&#160;<span
-                    aria-label="and then">></span> Show clipboard access</b>.</p>
+                    toggled under <b>Settings&#160;>
+                    Security &amp; privacy&#160;> Privacy controls&#160;> Show clipboard access</b>.</p>
                 </article>
 
                 <article id="hardware-identifiers">
@@ -898,9 +897,9 @@
                             HTTPS-based time updates in order to blend in with other devices.</p>
 
                             <p>Network time can be disabled with the toggle at
-                            <b>Settings&#160;<span aria-label="and then">></span>
-                            System&#160;<span aria-label="and then">></span> Date &amp;
-                            time&#160;<span aria-label="and then">></span> Set time automatically</b>.
+                            <b>Settings&#160;>
+                            System&#160;> Date &amp;
+                            time&#160;> Set time automatically</b>.
                             Unlike AOSP or the stock OS on the supported devices, GrapheneOS stops making
                             network time connections when using network time is disabled rather than just
                             not setting the clock based on it. The time zone is still obtained directly
@@ -931,8 +930,8 @@
                             portals without the user turning off their VPN.</p>
 
                             <p>You can change the connectivity check URLs via the
-                            <b>Settings&#160;<span aria-label="and then">></span> Network &amp;
-                            internet&#160;<span aria-label="and then">></span> Internet
+                            <b>Settings&#160;> Network &amp;
+                            internet&#160;> Internet
                             connectivity check</b> setting. At the moment, it can be toggled between
                             the <b>GrapheneOS server</b> (default), the <b>Standard (Google) server</b>
                             used by billions of other Android devices or <b>Off</b>.</p>
@@ -1051,8 +1050,8 @@
                             reverse proxy adds to that since it's unable to decrypt the
                             provisioned keys.</p>
 
-                            <p>A setting is added at <b>Settings&#160;<span aria-label="and then">></span>
-                            Network &amp; internet&#160;<span aria-label="and then">></span>
+                            <p>A setting is added at <b>Settings&#160;>
+                            Network &amp; internet&#160;>
                             Attestation key provisioning</b> for switching to directly using the
                             Google service if you prefer.</p>
 
@@ -1134,8 +1133,7 @@
                     as part of Widevine provisioning. This is another form of key provisioning for
                     per-app keys that are used when playing DRM protected media. DRM support is
                     enabled in the OS by default but we don't include any apps using it by default,
-                    since it's disabled in Vanadium. A setting is added at <b>Settings&#160;<span
-                    aria-label="and then">></span> Network &amp; Internet&#160;<span aria-label="and then">></span>
+                    since it's disabled in Vanadium. A setting is added at <b>Settings&#160;> Network &amp; Internet&#160;>
                     Widevine provisioning</b> for switching to directly using the Google service if
                     you prefer.</p>
 
@@ -1162,7 +1160,7 @@
                     configuration but most leave it at the default of supl.google.com. By default,
                     GrapheneOS overrides the carrier/fallback SUPL server and uses the
                     supl.grapheneos.org proxy. GrapheneOS adds a toggle for configuring SUPL in
-                    <b>Settings&#160;<span aria-label="and then">></span> Location</b> where you
+                    <b>Settings&#160;> Location</b> where you
                     can choose between the default <b>GrapheneOS proxy</b> supl.grapheneos.org,
                     the <b>Standard server</b> (carrier/fallback) or turning it <b>Off</b>
                     completely. GrapheneOS also disables sending IMSI and phone number as part of
@@ -1270,8 +1268,8 @@
 
                     <p>It isn't possible to directly override the DNS servers provided by the
                     network via DHCP. Instead, use the Private DNS feature in
-                    <b>Settings&#160;<span aria-label="and then">></span> Network &amp;
-                    internet&#160;<span aria-label="and then">></span> Private DNS</b> to set the
+                    <b>Settings&#160;> Network &amp;
+                    internet&#160;> Private DNS</b> to set the
                     hostname of a DNS-over-TLS server. It needs to have a valid certificate such as a
                     free certificate from Let's Encrypt. The OS will look up the Private DNS hostname
                     via the network provided DNS servers and will then force all other DNS requests
@@ -1346,8 +1344,8 @@
                 <article id="vpn-support">
                     <h3><a href="#vpn-support">What kind of VPN and Tor support is available?</a></h3>
 
-                    <p>VPNs can be configured under <b>Settings&#160;<span aria-label="and then">></span>
-                    Network &amp; internet&#160;<span aria-label="and then">></span> VPN</b>.
+                    <p>VPNs can be configured under <b>Settings&#160;>
+                    Network &amp; internet&#160;> VPN</b>.
                     Support for the following protocols is included: IKEv2/IPSec MSCHAPv2,
                     IKEv2/IPSec PSK and IKEv2/IPSec RSA. Apps can also provide userspace VPN
                     implementations. The only apps we can recommend are the official WireGuard
@@ -1379,8 +1377,7 @@
                     VPN service by the user. Apps cannot normally access network stats and cannot
                     directly request access to them. However, app-based stats can be explicitly
                     granted by users as part of access to app usage stats in
-                    <b>Settings&#160;<span aria-label="and then">></span> Apps&#160;<span
-                    aria-label="and then">></span> Special app access&#160;<span aria-label="and then">></span>
+                    <b>Settings&#160;> Apps&#160;> Special app access&#160;>
                     Usage access</b>.</p>
 
                     <p>This was previously part of the GrapheneOS privacy improvements, but became a
@@ -1618,7 +1615,7 @@
                     interfere with this use case at all. If you've changed it to a stricter value
                     such as completely disallowing USB-C data, it can be changed back to the default
                     "Charging-only when locked" value in
-                    <b>Settings&#160;<span aria-label="and then">></span> Security&#160;<span aria-label="and then">></span> Exploit protection&#160;<span aria-label="and then">></span> USB-C port</b>.</p>
+                    <b>Settings&#160;> Security&#160;> Exploit protection&#160;> USB-C port</b>.</p>
 
                     <p>To use an external drive, plug it into the phone and use the system file
                     manager to copy files to and from it.</p>
@@ -1629,8 +1626,7 @@
                     to transfer files between macOS and Android. After plugging in the phone to the
                     computer, there will be a notification showing the current USB mode with
                     charging as the default. Pressing the notification acts as a shortcut to
-                    <b>Settings&#160;<span aria-label="and then">></span> Connected devices&#160;<span
-                    aria-label="and then">></span> USB</b>. You can enable <b>File Transfer</b> (MTP)
+                    <b>Settings&#160;> Connected devices&#160;> USB</b>. You can enable <b>File Transfer</b> (MTP)
                     or <b>PTP</b> with this menu. It will provide read/write access to the entire
                     profile home directory, i.e. the top-level directory named after the device in
                     the system file manager which does not include internal app data. Due to needing

--- a/static/features.html
+++ b/static/features.html
@@ -642,8 +642,8 @@
                     enabled by default. When an app attempts to access sensors and receives zeroed
                     data due to being denied, GrapheneOS creates a notification that can be
                     easily disabled. The Sensors permission can be set to be disabled by default
-                    for user installed apps in <b>Settings&#160;<span aria-label="and then">></span>
-                    Security &amp; privacy&#160;<span aria-label="and then">></span>
+                    for user installed apps in <b>Settings&#160;>
+                    Security &amp; privacy&#160;>
                     More security &amp; privacy</b>.</p>
                 </section>
 
@@ -772,8 +772,8 @@
 
                     <p>On Android, each screenshot includes an EXIF Software tag with detailed OS
                     build/version information (<code>android.os.Build.DISPLAY</code>). It's the
-                    same value shown at <b>Settings&#160;<span aria-label="and then">></span>
-                    About device&#160;<span aria-label="and then">></span> Build number</b>. This
+                    same value shown at <b>Settings&#160;>
+                    About device&#160;> Build number</b>. This
                     leaks the OS, OS version and also usually the device family/model since builds are
                     specific to a family of devices. GrapheneOS completely disables this
                     tag.</p>
@@ -784,8 +784,8 @@
                     isn't visible to the user. The date and time are already included in the file
                     name of the screenshot which is fully visible to the user and can be easily
                     modified by them without a third-party tool. GrapheneOS includes a toggle for
-                    turning this metadata back on in <b>Settings&#160;<span aria-label="and then">></span>
-                    Security &amp; privacy&#160;<span aria-label="and then">></span>
+                    turning this metadata back on in <b>Settings&#160;>
+                    Security &amp; privacy&#160;>
                     More security &amp; privacy</b> since some users may find it to be useful.</p>
                 </section>
 
@@ -958,9 +958,7 @@
                     with any such prompt in the OS).</p>
 
                     <p>The wipe does not require a reboot and cannot be interrupted. It can be set
-                    up at <b>Settings&#160;<span aria-label="and then">></span> Security &amp; privacy&#160;<span
-                    aria-label="and then">></span> Device unlock&#160;<span
-                    aria-label="and then">></span> Duress Password</b> in the owner profile. Duress
+                    up at <b>Settings&#160;> Security &amp; privacy&#160;> Device unlock&#160;> Duress Password</b> in the owner profile. Duress
                     PIN is solely used for PIN entry and duress password is solely used for password
                     entry. Both a duress PIN and password are mandatory to enable the feature to
                     account for different profiles that may have different unlock methods. Duress
@@ -1353,11 +1351,10 @@
                     search. Users can copy, share or save the currently shown logs to a file. A
                     description can be added to document why the logs were captured.</p>
 
-                    <p>Overall system logs can be accessed at <b>Settings&#160;<span aria-label="and then">></span>
-                    System&#160;<span aria-label="and then">></span> View logs</b>. Per-app logs can
-                    be accessed at <b>Settings&#160;<span aria-label="and then">></span>
-                    Apps&#160;<span aria-label="and then">></span> App name&#160;<span
-                    aria-label="and then">></span> View logs</b>.</p>
+                    <p>Overall system logs can be accessed at <b>Settings&#160;>
+                    System&#160;> View logs</b>. Per-app logs can
+                    be accessed at <b>Settings&#160;>
+                    Apps&#160;> App name&#160;> View logs</b>.</p>
 
                     <p>We implement user-facing crash reporting tied to our log viewer for OS and
                     app crashes, greatly improving upon the very limited user-facing crash reporting
@@ -1376,9 +1373,9 @@
                     including base OS apps, but too many user installed apps have latent memory
                     corruption bugs and we need to provide the option to work around them.</p>
 
-                    <p>Users can enable more system crash reporting via <b>Settings&#160;<span aria-label="and then">></span>
-                    Security &amp; privacy&#160;<span aria-label="and then">></span>
-                    More security &amp; privacy&#160;<span aria-label="and then">></span>
+                    <p>Users can enable more system crash reporting via <b>Settings&#160;>
+                    Security &amp; privacy&#160;>
+                    More security &amp; privacy&#160;>
                     Notify about system process crashes</b>. We don't enable reporting all kernel or
                     system process crashes by default since we can't manage triaging and
                     investigating every single Android OS bug causing a crash. We're focused on the
@@ -1438,7 +1435,7 @@
                         list of all user-created directories (this is allowed on Android). The list of
                         files is hidden from such apps on both Android and GrapheneOS.</li>
                         <li>Screenshot shutter sound is toggleable using the <b>Tap &amp; click
-                        sounds</b> option in <b>Settings&#160;<span aria-label="and then">></span>
+                        sounds</b> option in <b>Settings&#160;>
                         Sound &amp; vibration</b> while still following the standard method of
                         putting the device on vibration/silent mode to turn off the screenshot shutter
                         sound.</li>

--- a/static/install/cli.html
+++ b/static/install/cli.html
@@ -172,12 +172,11 @@
 
                 <p>OEM unlocking needs to be enabled from within the operating system.</p>
 
-                <p>Enable the developer options menu by going to <b>Settings&#160;<span
-                aria-label="and then">></span> About phone/tablet</b> and repeatedly
+                <p>Enable the developer options menu by going to <b>Settings&#160;> About phone/tablet</b> and repeatedly
                 pressing the <b>Build number</b> menu entry until developer mode is enabled.</p>
 
-                <p>Next, go to <b>Settings&#160;<span aria-label="and then">></span>
-                System&#160;<span aria-label="and then">></span> Developer options</b> and
+                <p>Next, go to <b>Settings&#160;>
+                System&#160;> Developer options</b> and
                 toggle on the <b>OEM unlocking</b> setting. On device model variants (SKUs) which
                 support being sold as locked devices by carriers, enabling <b>OEM unlocking</b>
                 requires internet access so that the stock OS can check if the device was sold as

--- a/static/install/web.html
+++ b/static/install/web.html
@@ -175,12 +175,11 @@
 
                 <p>OEM unlocking needs to be enabled from within the operating system.</p>
 
-                <p>Enable the developer options menu by going to <b>Settings&#160;<span
-                aria-label="and then">></span> About phone/tablet</b> and repeatedly
+                <p>Enable the developer options menu by going to <b>Settings&#160;> About phone/tablet</b> and repeatedly
                 pressing the <b>Build number</b> menu entry until developer mode is enabled.</p>
 
-                <p>Next, go to <b>Settings&#160;<span aria-label="and then">></span>
-                System&#160;<span aria-label="and then">></span> Developer options</b> and
+                <p>Next, go to <b>Settings&#160;>
+                System&#160;> Developer options</b> and
                 toggle on the <b>OEM unlocking</b> setting. On device model variants (SKUs) which
                 support being sold as locked devices by carriers, enabling <b>OEM unlocking</b>
                 requires internet access so that the stock OS can check if the device was sold as

--- a/static/releases.html
+++ b/static/releases.html
@@ -4653,7 +4653,7 @@
                     <ul>
                         <li>replace auto-reboot implementation with a new more hardened implementation based on a timer in the init process (since init crashing reboots the device, unlike system_server) which also avoids rebooting when the device hasn't been unlocked since boot</li>
                         <li>reduce default auto-reboot timer from 72 hours to 18 hours</li>
-                        <li>add log viewer available at <b>Settings&#160;<span aria-label="and then">></span> System&#160;<span aria-label="and then">></span> View logs</b> to avoid needing developer options for making useful bug reports and inspecting the device for issues</li>
+                        <li>add log viewer available at <b>Settings&#160;> System&#160;> View logs</b> to avoid needing developer options for making useful bug reports and inspecting the device for issues</li>
                         <li>reimplement our user-facing crash reporting infrastructure with our new log viewer app</li>
                         <li>Settings: add links to log viewer in app info and system settings</li>
                         <li>show report button in sandboxed Google Play crash report UI</li>
@@ -5053,7 +5053,7 @@
                     <ul>
                         <li>add infrastructure for hardware memory tagging support</li>
                         <li>hardened_malloc: add support for hardware memory tagging launched with the ARMv9 cores on the Pixel 8 and Pixel 8 Pro</li>
-                        <li>Settings: enable memory tagging toggle at <b>Settings&#160;<span aria-label="and then">></span> Security&#160;<span aria-label="and then">></span> More security settings&#160;<span aria-label="and then">></span> Advanced memory protection</b> beta on supported devices (Pixel 8 and Pixel 8 Pro)</li>
+                        <li>Settings: enable memory tagging toggle at <b>Settings&#160;> Security&#160;> More security settings&#160;> Advanced memory protection</b> beta on supported devices (Pixel 8 and Pixel 8 Pro)</li>
                         <li>Pixel 8, Pixel 8 Pro: enable memory tagging support for everything built by GrapheneOS (other than Vanadium, since Chromium currently disables it) and also user installed apps without native libraries (will be expanded to Vanadium later along with the option to use it for all user installed apps)</li>
                         <li>Pixel 8, Pixel 8 Pro: use asymmetric memory tagging mode on all cores to provide much higher security than asynchronous mode without much more overhead unlike the very expensive synchronous mode without any clear security benefits over asymmetric</li>
                         <li>enable parallel compilation of non-precompiled bytecode to native code for first-boot and first-boot-after-update with 2 processes for now (can be increased later)</li>
@@ -6186,7 +6186,7 @@
                     <p>Changes since the 2023020600 release:</p>
 
                     <ul>
-                        <li>add toggle to <b>Settings&#160;<span aria-label="and then">></span> Location</b> for force disabling SUPL as a carrier-independent replacement for editing APN configuration since editing APN configuration is unintuitive, not fully respected on Tensor SoC devices and users with no carrier should be able to disable it without using airplane mode</li>
+                        <li>add toggle to <b>Settings&#160;> Location</b> for force disabling SUPL as a carrier-independent replacement for editing APN configuration since editing APN configuration is unintuitive, not fully respected on Tensor SoC devices and users with no carrier should be able to disable it without using airplane mode</li>
                         <li>Vanadium: update Chromium base to 110.0.5481.64</li>
                         <li>GmsCompatConfig: update max supported version of Play Store</li>
                         <li>Apps: update to <a href="https://github.com/GrapheneOS/Apps/releases/tag/15">version 15</a></li>
@@ -7617,7 +7617,7 @@
                     <p>Changes since the 2022062200 release:</p>
 
                     <ul>
-                        <li>add opt-in support for forwarding notifications to the active user from users in the background with information censored in the same way as on the lockscreen (can be enabled in <b>Settings&#160;<span aria-label="and then">></span> System&#160;<span aria-label="and then">></span> Multiple users</b> for each user you want to forward their notifications)</li>
+                        <li>add opt-in support for forwarding notifications to the active user from users in the background with information censored in the same way as on the lockscreen (can be enabled in <b>Settings&#160;> System&#160;> Multiple users</b> for each user you want to forward their notifications)</li>
                         <li>set correct tile label for our battery share quick tile</li>
                         <li>Vanadium: update Chromium base to 103.0.5060.70</li>
                         <li>Vanadium: disable reporting support (Report-To, report-uri) again</li>
@@ -7847,7 +7847,7 @@
 
                     <ul>
                         <li>Sandboxed Google Play compatibility layer (GmsCompat): significantly improve compatibility of the default enabled geolocation API rerouting feature</li>
-                        <li>remove timestamp from screenshot EXIF metadata by default and add a toggle to <b>Settings&#160;<span aria-label="and then">></span> Privacy</b> for enabling it</li>
+                        <li>remove timestamp from screenshot EXIF metadata by default and add a toggle to <b>Settings&#160;> Privacy</b> for enabling it</li>
                         <li>work around slow unlock animation</li>
                         <li>kernel (Pixel 6, Pixel 6 Pro): update GKI base to ASB-2022-05-05_12-5.10</li>
                         <li>Dialer: add fixes for Bluetooth audio call redirection and BLE devices</li>
@@ -8156,7 +8156,7 @@
 
                     <ul>
                         <li>ThemePicker: add toggle for using wallpaper-extracted colors as the color scheme (Monet)</li>
-                        <li>add toggle for exec-based spawning in <b>Settings&#160;<span aria-label="and then">></span> Security</b></li>
+                        <li>add toggle for exec-based spawning in <b>Settings&#160;> Security</b></li>
                         <li>GrapheneOS Keyboard: enable spellchecking for Czech and Dutch languages</li>
                         <li>Vanadium: update Chromium base to 99.0.4844.88</li>
                         <li>Camera: update to <a href="https://github.com/GrapheneOS/Camera/releases/tag/17">version 17</a></li>
@@ -8487,7 +8487,7 @@
 
                     <ul>
                         <li>Pixel 3, Pixel 3 XL: add GmsCompat app which was meant to be added by the previous release</li>
-                        <li>Pixel 6, Pixel 6 Pro: revert accidental enabling of dark mode by default, which we plan to do by default in the future across devices once the Contacts and Messaging apps are updated to support it (you can set your own preference in <b>Settings&#160;<span aria-label="and then">></span> Display&#160;<span aria-label="and then">></span> Dark theme</b>)</li>
+                        <li>Pixel 6, Pixel 6 Pro: revert accidental enabling of dark mode by default, which we plan to do by default in the future across devices once the Contacts and Messaging apps are updated to support it (you can set your own preference in <b>Settings&#160;> Display&#160;> Dark theme</b>)</li>
                     </ul>
                 </article>
 
@@ -9549,7 +9549,7 @@
 
                     <ul>
                         <li>kernel (Pixel 4a (5G), Pixel 5): rebuild with updated techpack/camera submodule</li>
-                        <li>add back support for fully disabling native debugging (ptrace) support in <b>Settings&#160;<span aria-label="and then">></span> Security</b></li>
+                        <li>add back support for fully disabling native debugging (ptrace) support in <b>Settings&#160;> Security</b></li>
                         <li>kernel (Pixel 3, Pixel 3 XL, Pixel 3a, Pixel 3a XL, Pixel 4, Pixel 4 XL, Pixel 4a, Pixel 4a (5G), Pixel 5): enable support for native debugging (ptrace) toggle via Yama</li>
                         <li>Settings: add back extra field with bootloader version</li>
                         <li>Settings: only allow disabling Vanadium WebView library via developer tools since disabling it breaks app compatibility and almost always results in crashes rather than user friendly errors, including for base OS components using it</li>
@@ -9954,9 +9954,7 @@
                     <h3><a href="#2020.11.05.18">2020.11.05.18</a></h3>
 
                     <p>While waiting for this release to become available, you can manually add a
-                    battery optimization exemption for the Clock app via <b>Settings&#160;<span
-                    aria-label="and then">></span> Apps &amp; notifications&#160;<span
-                    aria-label="and then">></span> Special app access&#160;<span aria-label="and then">></span>
+                    battery optimization exemption for the Clock app via <b>Settings&#160;> Apps &amp; notifications&#160;> Special app access&#160;>
                     Battery optimization</b> where you can select <b>All apps</b>, scroll
                     down to the Clock app and manually add an exemption. Should get this added upstream.</p>
 

--- a/static/usage.html
+++ b/static/usage.html
@@ -112,12 +112,11 @@
                 like it. Our experience is that when armed with the appropriate knowledge, the
                 vast majority of users prefer the newer gesture navigation approach.</p>
 
-                <p>The system navigation mode can be configured in <b>Settings&#160;<span
-                aria-label="and then">></span> System&#160;<span aria-label="and then">></span>
-                Gestures&#160;<span aria-label="and then">></span> Navigation
-                mode</b>. The same menu is also available in <b>Settings&#160;<span aria-label="and then">></span>
-                Accessibility&#160;<span aria-label="and then">></span> System
-                controls&#160;<span aria-label="and then">></span> Navigation mode</b>.</p>
+                <p>The system navigation mode can be configured in <b>Settings&#160;> System&#160;>
+                Gestures&#160;> Navigation
+                mode</b>. The same menu is also available in <b>Settings&#160;>
+                Accessibility&#160;> System
+                controls&#160;> Navigation mode</b>.</p>
 
                 <section id="gesture-navigation">
                     <h3><a href="#gesture-navigation">Gesture navigation</a></h3>
@@ -377,9 +376,8 @@
                 already.</p>
 
                 <p>GrapheneOS disables showing the characters as passwords are typed by default. You
-                can enable this in <b>Settings&#160;<span aria-label="and then">></span>
-                Security &amp; privacy&#160;<span aria-label="and then">></span> Privacy&#160;<span
-                aria-label="and then">></span> Show passwords</b>.</p>
+                can enable this in <b>Settings&#160;>
+                Security &amp; privacy&#160;> Privacy&#160;> Show passwords</b>.</p>
 
                 <p>Third party accessibility services can be installed and activated. This
                 includes the ones made by Google. Most of these will work but some may have a hard
@@ -426,8 +424,7 @@
                 <section id="updates-settings">
                     <h3><a href="#updates-settings">Settings</a></h3>
 
-                    <p>The settings are available in the Settings app in <b>System&#160;<span
-                    aria-label="and then">></span> System update</b>.</p>
+                    <p>The settings are available in the Settings app in <b>System&#160;> System update</b>.</p>
 
                     <p>The "Check for updates" option will manually trigger an update check as soon as
                     possible. It will still wait for the configuration conditions listed below to be
@@ -485,7 +482,7 @@
                     <p>It's highly recommended to leave automatic updates enabled and to configure
                     the permitted networks if the bandwidth usage is a problem on your mobile data
                     connection. However, it's possible to turn off the update client by going to
-                    <b>Settings&#160;<span aria-label="and then">></span> Apps</b>, enabling Show
+                    <b>Settings&#160;> Apps</b>, enabling Show
                     system via the menu, selecting System Updater and disabling the app. If you do
                     this, you'll need to remember to enable it again to start receiving updates.</p>
                 </section>
@@ -532,8 +529,8 @@
                 USB-C or pogo pins while the OS is booted. For the majority of devices without pogo
                 pins, the setting is labelled <b>USB-C port</b>.</p>
 
-                <p>The setting is available in <b>Settings&#160;<span aria-label="and then">></span>
-                Security&#160;<span aria-label="and then">></span> Exploit protection</b>.</p>
+                <p>The setting is available in <b>Settings&#160;>
+                Security&#160;> Exploit protection</b>.</p>
 
                 <p>The setting has five modes:</p>
 
@@ -822,9 +819,9 @@
                 profiles, so it also provides a temporary set of device identifiers across profiles
                 for each boot via the shared randomized values.</p>
 
-                <p>This feature can be disabled via <b>Settings&#160;<span aria-label="and then">></span>
-                Security &amp; privacy&#160;<span aria-label="and then">></span>
-                Exploit protection&#160;<span aria-label="and then">></span> Secure app spawning</b>
+                <p>This feature can be disabled via <b>Settings&#160;>
+                Security &amp; privacy&#160;>
+                Exploit protection&#160;> Secure app spawning</b>
                 if you prefer to have faster cold start app spawning time and lower app process
                 memory usage instead of the substantial security benefits and the removal of the
                 only known remaining direct device identifiers across profiles (i.e. not depending
@@ -856,8 +853,7 @@
                 application when it violates the rules.</p>
 
                 <p>You can enable our exploit protection compatibility mode via
-                <b>Settings&#160;<span aria-label="and then">></span> Apps&#160;<span
-                aria-label="and then">></span> <var>APP</var>&#160;<span aria-label="and then">></span>
+                <b>Settings&#160;> Apps&#160;> <var>APP</var>&#160;>
                 Exploit protection compatibility mode</b>. The exploit protection compatibility mode
                 toggle will:</p>
                 <ul>
@@ -915,9 +911,8 @@
                     to delete the saved network afterwards.</p>
 
                     <p>Wi-Fi and Bluetooth scanning for improving location detection are disabled by
-                    default, unlike the stock OS. These can be toggled in <b>Settings&#160;<span
-                    aria-label="and then">></span> Location&#160;<span aria-label="and then">></span>
-                    Location services&#160;<span aria-label="and then">></span> Wi-Fi and Bluetooth
+                    default, unlike the stock OS. These can be toggled in <b>Settings&#160;> Location&#160;>
+                    Location services&#160;> Wi-Fi and Bluetooth
                     scanning</b>. These features enable scanning even when Wi-Fi or Bluetooth is
                     disabled, so these need to be kept disabled to fully disable the radios when
                     Wi-Fi and Bluetooth are disabled. GrapheneOS itself doesn't currently include a
@@ -933,10 +928,8 @@
                     <h3><a href="#wifi-privacy-associated">Associated with an Access Point (AP)</a></h3>
 
                     <p>Associated MAC randomization is performed by default. This can be controlled
-                    per-network in <b>Settings&#160;<span aria-label="and then">></span> Network
-                    &amp; internet&#160;<span aria-label="and then">></span> Internet&#160;<span
-                    aria-label="and then">></span> <var>NETWORK</var>&#160;<span
-                    aria-label="and then">></span> Privacy</b>.</p>
+                    per-network in <b>Settings&#160;> Network
+                    &amp; internet&#160;> Internet&#160;> <var>NETWORK</var>&#160;> Privacy</b>.</p>
 
                     <p>In the stock OS, the default is to use a unique persistent random MAC address for
                     each network. It has 2 options available: "Use randomized MAC (default)" and "Use
@@ -975,15 +968,13 @@
                 <p>For more information on the network location feature and how it works, see the
                 <a href="/features#network-location">features section</a>.</p>
 
-                <p>The setting can be found at <b>Settings&#160;<span aria-label="and then">></span>
-                Location&#160;<span aria-label="and then">></span> Location services&#160;<span
-                aria-label="and then">></span> Network location</b>. The available options are using
+                <p>The setting can be found at <b>Settings&#160;>
+                Location&#160;> Location services&#160;> Network location</b>. The available options are using
                 Apple's network location service, or a GrapheneOS proxy to that service.</p>
 
                 <p>To use this feature, you need to make sure that you either have Wi-Fi enabled, or that
-                Wi-Fi scanning is enabled at <b>Settings&#160;<span aria-label="and then">></span>
-                Location&#160;<span aria-label="and then">></span> Location services&#160;<span
-                aria-label="and then">></span> Wi-Fi scanning</b>, or you have cell reception (far less accurate).
+                Wi-Fi scanning is enabled at <b>Settings&#160;>
+                Location&#160;> Location services&#160;> Wi-Fi scanning</b>, or you have cell reception (far less accurate).
                 Enabling the Wi-Fi scanning setting will allow you to use Wi-Fi-based network location even if
                 you disable the global Wi-Fi toggle.</p>
             </section>
@@ -992,10 +983,8 @@
                 <h2><a href="#lte-only-mode">LTE-only mode</a></h2>
 
                 <p>If you have a reliable LTE connection from your carrier, you can reduce attack
-                surface by disabling 2G, 3G and 5G connectivity in <b>Settings&#160;<span
-                aria-label="and then">></span> Network &amp; internet&#160;<span aria-label="and then">></span>
-                SIMs&#160;<span aria-label="and then">></span> <var>SIM</var>&#160;<span
-                aria-label="and then">></span> Preferred network type</b>. Traditional voice calls will only
+                surface by disabling 2G, 3G and 5G connectivity in <b>Settings&#160;> Network &amp; internet&#160;>
+                SIMs&#160;> <var>SIM</var>&#160;> Preferred network type</b>. Traditional voice calls will only
                 work in the LTE-only mode if you have either an LTE connection and VoLTE (Voice over LTE) support or
                 a Wi-Fi connection and VoWi-Fi (Voice over Wi-Fi) support. VoLTE / VoWi-Fi works on GrapheneOS for
                 most carriers unless they restrict it to carrier phones. Some carriers may be missing VoWi-Fi due to
@@ -1107,8 +1096,7 @@
                     <h3><a href="#sandboxed-google-play-configuration">Configuration</a></h3>
 
                     <p>The compatibility layer has a configuration menu available at
-                    <b>Settings&#160;<span aria-label="and then">></span> Apps&#160;<span
-                    aria-label="and then">></span> Sandboxed Google Play</b>.</p>
+                    <b>Settings&#160;> Apps&#160;> Sandboxed Google Play</b>.</p>
 
                     <p>By default, apps using Google Play geolocation are redirected to our own
                     implementation on top of the standard OS geolocation service. You don't need to
@@ -1128,8 +1116,8 @@
                         <li>Use the "Google Location Accuracy" link from the sandboxed Google Play configuration
                         menu to access the Google Play services menu for opting into their network location service.</li>
                         <li>To take advantage of Wi-Fi and Bluetooth scanning, you also need to enable the scanning
-                        toggles in <b>Settings&#160;<span aria-label="and then">></span>
-                        Location &#160;<span aria-label="and then">></span> Location services</b>
+                        toggles in <b>Settings&#160;>
+                        Location &#160;> Location services</b>
                         which are disabled by default and control whether apps with the required permissions
                         can scan when Wi-Fi and Bluetooth are otherwise disabled.</li>
                     </ol>
@@ -1145,8 +1133,7 @@
                     <p>The menu also provides links to this usage guide, Play services system
                     settings, Play Store system settings and Google settings. The Play services and
                     Play Store system settings are only included for convenience since they can be
-                    accessed the same way as any other app via <b>Settings&#160;<span
-                    aria-label="and then">></span> Apps</b>.</p>
+                    accessed the same way as any other app via <b>Settings&#160;> Apps</b>.</p>
                 </section>
 
                 <section id="sandboxed-google-play-location-sharing">
@@ -1201,8 +1188,8 @@
                 and never shares data to Google Play even when installed. It won't connect to a
                 Google service unless the carrier uses one themselves.</p>
 
-                <p>eSIM support can be enabled in <b>Settings&#160;<span aria-label="and then">></span>
-                Network &amp; internet&#160;<span aria-label="and then">></span>
+                <p>eSIM support can be enabled in <b>Settings&#160;>
+                Network &amp; internet&#160;>
                 eSIM support</b>. The toggle is persistent across every boot.</p>
 
                 <p>Note that if the eSIM installation process does not progress past the
@@ -1232,9 +1219,8 @@
                 depends on sandboxed Google Play, you'll be prompted to install it if it's not
                 already installed.</p>
 
-                <p>After installation, Android Auto has to be set up from the <b>Settings&#160;<span
-                aria-label="and then">></span> Apps&#160;<span aria-label="and then">></span>
-                Sandboxed Google Play&#160;<span aria-label="and then">></span> Android Auto</b>
+                <p>After installation, Android Auto has to be set up from the <b>Settings&#160;> Apps&#160;>
+                Sandboxed Google Play&#160;> Android Auto</b>
                 configuration screen, which contains permission toggles, links to related
                 configuration screens, configuration tips, and links to optional Android Auto
                 dependencies.</p>
@@ -1280,8 +1266,8 @@
                 <p>Many of these apps have their own crude anti-tampering mechanisms trying to
                 prevent inspecting or modifying the app in a weak attempt to hide their code and API
                 from security researchers. GrapheneOS allows users to disable <b>Native code
-                debugging</b> via a toggle in <b>Settings&#160;<span aria-label="and then">></span>
-                Security &amp; privacy&#160;<span aria-label="and then">></span> Exploit protection</b>
+                debugging</b> via a toggle in <b>Settings&#160;>
+                Security &amp; privacy&#160;> Exploit protection</b>
                 to improve the app sandbox and this can interfere with apps debugging their
                 own code to add a barrier to analyzing the app. You should try enabling this again if you've
                 disabled it and are encountering compatibility issues with these kinds of apps.</p>
@@ -1324,9 +1310,8 @@
                 verified by the OS by marking them with <code>autoVerify</code> in their manifest.
                 The OS will securely confirm that the domain authorizes the app to handle the
                 domain's URLs. Users can also manually enable an app's link associations via
-                <b>Settings&#160;<span aria-label="and then">></span> Apps&#160;<span
-                aria-label="and then">></span> <var>APP</var>&#160;<span aria-label="and then">></span>
-                Open by default&#160;<span aria-label="and then">></span> Add link</b>. Apps can ask
+                <b>Settings&#160;> Apps&#160;> <var>APP</var>&#160;>
+                Open by default&#160;> Add link</b>. Apps can ask
                 users to enable the associations and send them to this page in the Settings app.</p>
 
                 <p>As an example, the first party YouTube app will have the app links verified by
@@ -1400,16 +1385,13 @@
                 <ul>
                     <li>Some carriers require you to explicitly opt in to use services such as Wi-Fi calling.
                         Consult your carrier's documentation on the process for this or contact them.</li>
-                    <li><b>Reset Mobile Network Settings</b> in <b>Settings&#160;<span
-                        aria-label="and then">></span> System&#160;<span aria-label="and then">></span>
+                    <li><b>Reset Mobile Network Settings</b> in <b>Settings&#160;> System&#160;>
                         Reset options</b> and then reboot the device.</li>
                     <li>USA users only: You may need to request your carrier to enable CDMA-less mode if
                         you have issues.</li>
                     <li>Follow your carrier's instructions for setting up APNs, this can be found in
-                        <b>Settings&#160;<span aria-label="and then">></span> Network &amp;
-                        internet&#160;<span aria-label="and then">></span> SIMs&#160;<span
-                        aria-label="and then">></span> <var>SIM</var>&#160;<span
-                        aria-label="and then">></span> Access Point Names</b></li>
+                        <b>Settings&#160;> Network &amp;
+                        internet&#160;> SIMs&#160;> <var>SIM</var>&#160;> Access Point Names</b></li>
                     <li>If calls do not work and you have <a href="#lte-only-mode">LTE-only mode</a> enabled,
                         try toggling it off. If "Allow 2G" is disabled, try toggling it back on. Your carrier
                         may not properly support VoLTE.</li>
@@ -1418,9 +1400,8 @@
 
                 <p>Some carriers may restrict functionality, such as VoLTE, on imported Pixel
                 devices as they only whitelist the IMEI ranges of Pixel device SKUs which were sold
-                locally. You can check your SKU on GrapheneOS by going to <b>Settings&#160;<span
-                aria-label="and then">></span> About phone&#160;<span aria-label="and then">></span>
-                Model&#160;<span aria-label="and then">></span> Hardware SKU</b> and using the <a
+                locally. You can check your SKU on GrapheneOS by going to <b>Settings&#160;> About phone&#160;>
+                Model&#160;> Hardware SKU</b> and using the <a
                 href="https://support.google.com/pixelphone/answer/7158570">official Google
                 documentation</a>. You should check if such functionality works on the stock OS to troubleshoot.
                 It is not possible to change the IMEI on a production device and GrapheneOS cannot add support for


### PR DESCRIPTION
Despite Google's developer documentation style guide for [UI navigation](https://developers.google.com/style/accessibility#ui-navigation), the aria-label was probably not the right approach. Screen readers would have inconsistent support anyway.

```
perl -0777 -i -pe 's!<span\W*aria-label="and then">\W*(.)\W*<\/span>!\1!msg' static/*.html static/**/*.html
````

Fix: https://github.com/GrapheneOS/grapheneos.org/pull/1316