### PR TITLE
add PosteID to list of apps banning GrapheneOS

### DIFF
--- a/static/articles/attestation-compatibility-guide.html
+++ b/static/articles/attestation-compatibility-guide.html
@@ -161,6 +161,7 @@
                     <li><a href="https://play.google.com/store/apps/details?id=com.swisssign.swissid.mobile" rel="nofollow">SwissID</a></li>
                     <li><a href="https://play.google.com/store/apps/details?id=de.tk.tkapp" rel="nofollow">TK-App</a> (German health insurance app which uses it for fingerprint login)</li>
                     <li><a href="https://play.google.com/store/apps/details?id=it.pagopa.io.app" rel="nofollow">IO</a> (Italian government app which uses it for the digital wallet feature)</li>
+                    <li><a href="https://play.google.com/store/apps/details?id=posteitaliane.posteapp.appposteid" rel="nofollow">PosteID (Italian postal service’s app used to access the national digital identity system "SPID")</a></li>
                     <li><a href="https://play.google.com/store/apps/details?id=sg.ndi.sp" rel="nofollow">Singpass</a></li>
                 </ul>
 


### PR DESCRIPTION
The PosteID app, owned by Poste Italiane - the Italian national postal operator - has recently adopted the Play Integrity API, which now prevents the application from running on GrapheneOS and results in an error message at startup.

The developer email listed on the Play Store, `assistenza_posteapp@poste.it`, is not functional. This morning I attempted to file a complaint via `servizio.clienti@posteitaliane.it`; I will update you if I receive a response.

Refs:
- https://github.com/GrapheneOS/os-issue-tracker/issues/6646
- https://discuss.grapheneos.org/d/28060-posteid-spid-provider-on-grapheneos/21