### PR TITLE
Fix: PosteID formatting in attestation compatibility guide

### DIFF
--- a/static/articles/attestation-compatibility-guide.html
+++ b/static/articles/attestation-compatibility-guide.html
@@ -161,7 +161,7 @@
                     <li><a href="https://play.google.com/store/apps/details?id=com.swisssign.swissid.mobile" rel="nofollow">SwissID</a></li>
                     <li><a href="https://play.google.com/store/apps/details?id=de.tk.tkapp" rel="nofollow">TK-App</a> (German health insurance app which uses it for fingerprint login)</li>
                     <li><a href="https://play.google.com/store/apps/details?id=it.pagopa.io.app" rel="nofollow">IO</a> (Italian government app which uses it for the digital wallet feature)</li>
-                    <li><a href="https://play.google.com/store/apps/details?id=posteitaliane.posteapp.appposteid" rel="nofollow">PosteID (Italian postal service’s app used to access the national digital identity system "SPID")</a></li>
+                    <li><a href="https://play.google.com/store/apps/details?id=posteitaliane.posteapp.appposteid" rel="nofollow">PosteID</a> (Italian postal service’s app used to access the national digital identity system "SPID")</li>
                     <li><a href="https://play.google.com/store/apps/details?id=sg.ndi.sp" rel="nofollow">Singpass</a></li>
                 </ul>
 


### PR DESCRIPTION
The PosteID entry's descriptive text was incorrectly placed inside the anchor tag (\<a>), causing the parentheses to be rendered in the link color (blue).