### PR TITLE
Add instructions on how to run yarn if it complains of MODULE_NOT_FOUND

### DIFF
--- a/static/build.html
+++ b/static/build.html
@@ -393,7 +393,9 @@ cd ../..</pre>
                     environment. (Note: On Debian, <code>yarn</code> is reserved for a binary in
                     <code>cmdtest</code>; use <code>yarnpkg</code> instead.)</p>
 
-                    <pre>yarn --cwd vendor/adevtool/ install</pre>
+                    <pre># If using the system package and yarn complains about MODULE_NOT_FOUND, uninstall then reinstall yarn via npm
+# For example, `sudo apt purge yarnpkg && npm install yarn`
+yarn --cwd vendor/adevtool/ install</pre>
 
                     <p>Download, extract and prepare the vendor files:</p>
 


### PR DESCRIPTION
The ubuntu system package appears to be broken / outdated somehow: when I try to run the yarn command in build.html

```
$ yarnpkg --cwd vendor/adevtool/ install
node:internal/modules/cjs/loader:1424
  throw err;
  ^

Error: Cannot find module '@babel/runtime/helpers/interopRequireDefault'
Require stack:
- /usr/share/nodejs/yarn/lib/cli/index.js
- /usr/share/nodejs/yarn/bin/yarn.js
    at Module._resolveFilename (node:internal/modules/cjs/loader:1421:15)
    at defaultResolveImpl (node:internal/modules/cjs/loader:1059:19)
    at resolveForCJSWithHooks (node:internal/modules/cjs/loader:1064:22)
    at Module._load (node:internal/modules/cjs/loader:1227:37)
    at TracingChannel.traceSync (node:diagnostics_channel:328:14)
    at wrapModuleLoad (node:internal/modules/cjs/loader:245:24)
    at Module.require (node:internal/modules/cjs/loader:1504:12)
    at require (node:internal/modules/helpers:152:16)
    at Object.<anonymous> (/usr/share/nodejs/yarn/lib/cli/index.js:3:30)
    at Module._compile (node:internal/modules/cjs/loader:1761:14) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/usr/share/nodejs/yarn/lib/cli/index.js',
    '/usr/share/nodejs/yarn/bin/yarn.js'
  ]
}

Node.js v24.11.1
```

It seems like the `npm` version of the utility fixes this, so recommend that.

Note: perhaps the installation instructions should simply always recommend installing the package via npm?