### PR TITLE
static/install/web: clarify device requirements

### DIFF
--- a/static/install/web.html
+++ b/static/install/web.html
@@ -83,7 +83,7 @@
             <section id="prerequisites">
                 <h2><a href="#prerequisites">Prerequisites</a></h2>
 
-                <p>You need a computer for running the web installer with at least 2GB of free
+                <p>You need a device for running the web installer with at least 2GB of free
                 memory available and 32GB of free storage space. The web installer can be run on an
                 Android phone or tablet, unlike the command-line installation.</p>
 


### PR DESCRIPTION
This clarifies that a _computer_ in the PC sense isn't necessary.
(I assume this sentence was copied from the CLI install instructions without sufficient modification, originally.)