### PR TITLE
update best development devices

### DIFF
--- a/static/build.html
+++ b/static/build.html
@@ -157,7 +157,7 @@
                     GrapheneOS release. Newer generation devices have stronger hardware / firmware
                     security and hardware-based OS security features and are better development
                     devices for that reason. It's not possible to work on everything via past
-                    generation devices. The best development devices are the Pixel 6 and 7 series.
+                    generation devices. The best development devices are the Pixel 8 and 9 series.
                     </p>
 
                     <p>SDK emulator target:</p>

--- a/static/build.html
+++ b/static/build.html
@@ -157,7 +157,7 @@
                     GrapheneOS release. Newer generation devices have stronger hardware / firmware
                     security and hardware-based OS security features and are better development
                     devices for that reason. It's not possible to work on everything via past
-                    generation devices. The best development devices are the Pixel 8 and 9 series.
+                    generation devices. The best development devices are Pixels series 8 to 10.
                     </p>
 
                     <p>SDK emulator target:</p>


### PR DESCRIPTION
<details>The best GrapheneOS development devices are no longer Pixels series 🫲6 7🫱</details>