### PR TITLE
Reword 'no Google apps and services' section

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -105,8 +105,8 @@
                 <section id="never-google-services">
                     <h2><a href="#never-google-services">No Google apps or services</a></h2>
 
-                    <p>GrapheneOS will never include either Google Play services or another
-                    implementation of Google services like microG. It's possible to install Play
+                    <p>GrapheneOS will never include Google Play services, nor will we ever include another
+                    implementation of Google services like microG. It's possible to install Play
                     services as a set of fully sandboxed apps without special privileges via our
                     <a href="/usage#sandboxed-google-play">sandboxed Google Play compatibility
                     layer</a>. See <a href="/faq#google-services">the FAQ section</a> for more


### PR DESCRIPTION
An 'either... or' grammar structure opens the possibility for one or the other to happen, so I changed the sentence to a 'never... nor... ever' structure