### PR TITLE
add TK-Ident & TK-Doc to list of apps banning GrapheneOS

### DIFF
--- a/static/articles/attestation-compatibility-guide.html
+++ b/static/articles/attestation-compatibility-guide.html
@@ -159,7 +159,9 @@
                     <li><a href="https://play.google.com/store/apps/details?id=com.mcdonalds.mobileapp" rel="nofollow">McDonald's</a> (International app used for many but not all countries not including the US)</li>
                     <li><a href="https://play.google.com/store/apps/details?id=com.ridedott.rider" rel="nofollow">Dott</a></li>
                     <li><a href="https://play.google.com/store/apps/details?id=com.swisssign.swissid.mobile" rel="nofollow">SwissID</a></li>
-                    <li><a href="https://play.google.com/store/apps/details?id=de.tk.tkapp" rel="nofollow">TK-App</a> (German health insurance app which uses it for fingerprint login)</li>
+                    <li><a href="https://play.google.com/store/apps/details?id=de.tk.tkapp" rel="nofollow">TK-App</a> (Blocks access to TK-Safe, TK-GesundheitsMessenger, fingerprint login)</li>
+                    <li><a href="https://play.google.com/store/apps/details?id=de.telearzt.tkchat" rel="nofollow">TK-Doc</a></li>
+                    <li><a href="https://play.google.com/store/apps/details?id=de.tk.apps.android.tkident" rel="nofollow">TK-Ident</a></li>
                     <li><a href="https://play.google.com/store/apps/details?id=it.pagopa.io.app" rel="nofollow">IO</a> (Italian government app which uses it to gate access to the digital wallet feature)</li>
                     <li><a href="https://play.google.com/store/apps/details?id=posteitaliane.posteapp.appposteid" rel="nofollow">PosteID</a> (Italian postal service’s app used to access the national digital identity system "SPID")</li>
                     <li><a href="https://play.google.com/store/apps/details?id=sg.ndi.sp" rel="nofollow">Singpass</a></li>


### PR DESCRIPTION
For context, I originally suggested adding these apps here: https://bsky.app/profile/felschr.com/post/3mbhn6xphok2g

I also updated info for TK-App including requirements how to at get it partially working on GrapheneOS.

Let me know if the nested list & footnotes work for you or if I should change something.