### PR TITLE
Specify how features like MTE are only supported on Pixels 8th gen and above

### DIFF
--- a/static/faq.html
+++ b/static/faq.html
@@ -234,9 +234,9 @@
                         <li>Pixel 8</li>
                     </ul>
 
-                    <p>8th/9th generation Pixels provide a minimum guarantee of 7 years of support
-                    from launch instead of the previous 5 year minimum guarantee. 8th/9th generation
-                    Pixels also bring support for the incredibly powerful hardware memory tagging
+                    <p>8th generation Pixels and above provide a minimum guarantee of 7 years of support
+                    from launch instead of the previous 5 year minimum guarantee. 8th generation
+                    Pixels and above also bring support for the incredibly powerful hardware memory tagging
                     security feature as part of moving to new ARMv9 CPU cores. GrapheneOS uses
                     hardware memory tagging by default to protect the base OS and known compatible
                     user installed apps against exploitation, with the option to use it for all apps

--- a/static/features.html
+++ b/static/features.html
@@ -355,11 +355,11 @@
                                     allocations to block C string overflows, absorb small overflows
                                     and detect linear overflows or other heap corruption when the
                                     canary value is checked (primarily on free)</li>
-                                    <li>Hardware memory tagging for slab allocations (128k and
-                                    below) providing probabilistic detection of all use-after-free
-                                    and inter-object overflows along with deterministic detection
-                                    of all small/linear overflows and use-after-free until it has
-                                    been reused once and gone through the quarantines twice</li>
+                                    <li>Hardware memory tagging (supported on 8th generation Pixels and 
+                                    above) for slab allocations (128k and below) providing probabilistic 
+                                    detection of all use-after-free and inter-object overflows along with 
+                                    deterministic detection of all small/linear overflows and use-after-free 
+                                    until it has been reused once and gone through the quarantines twice</li>
                                 </ul>
                             </li>
                             <li>On ARMv9, Branch Target Identification (BTI) and Pointer
@@ -1076,7 +1076,8 @@
                     <p>Some of the features added compared to standard mobile Chromium:</p>
 
                     <ul>
-                        <li>Hardware memory tagging (MTE) enabled for the main allocator</li>
+                        <li>Hardware memory tagging (MTE) enabled for the main allocator (supported
+                        on 8th generation pixels and above)</li>
                         <li>Type-based Control Flow Integrity (CFI)</li>
                         <li>Strong stack protector</li>
                         <li>Automatic zero-initialized variables</li>

--- a/static/features.html
+++ b/static/features.html
@@ -1077,7 +1077,7 @@
 
                     <ul>
                         <li>Hardware memory tagging (MTE) enabled for the main allocator (supported
-                        on 8th generation pixels and above)</li>
+                        on 8th generation Pixels and above)</li>
                         <li>Type-based Control Flow Integrity (CFI)</li>
                         <li>Strong stack protector</li>
                         <li>Automatic zero-initialized variables</li>


### PR DESCRIPTION
For the FAQ, now that Pixel 10 support is production ready, it should be mentioned how not just Pixels 8th and 9th generation have 7 year support and MTE. 

For the features section, I specified that only Pixels 8th gen and above have support for MTE.