### PR TITLE
add mada Pay to list of apps banning GrapheneOS

### DIFF
--- a/static/articles/attestation-compatibility-guide.html
+++ b/static/articles/attestation-compatibility-guide.html
@@ -165,6 +165,7 @@
                     <li><a href="https://play.google.com/store/apps/details?id=it.pagopa.io.app" rel="nofollow">IO</a> (Italian government app which uses it to gate access to the digital wallet feature)</li>
                     <li><a href="https://play.google.com/store/apps/details?id=posteitaliane.posteapp.appposteid" rel="nofollow">PosteID</a> (Italian postal service’s app used to access the national digital identity system "SPID")</li>
                     <li><a href="https://play.google.com/store/apps/details?id=sg.ndi.sp" rel="nofollow">Singpass</a></li>
+                    <li><a href="https://play.google.com/store/apps/details?id=com.mada.madapay" rel="nofollow">mada Pay</a> (Saudi NFC payment app)</li>
                 </ul>
 
                 <p>In addition to leaving feedback for these apps on the Play Store, file support


### PR DESCRIPTION
mada pay is the de facto platform to pay using NFC in Saudi Arabia (and other GCC countries). The app force closes when it checks integrity API, even when it returns **MEETS_BASIC_INTEGRITY**. Blocking integrity API access does not work.

<img width="1344" height="423" alt="Screenshot_20260131-161214_1" src="https://github.com/user-attachments/assets/f37d3904-0386-4eab-b7d4-863f187c1952" />

I have attempted to contact them to resolve this issue but they ignored my messages.