### PR TITLE
add EasyPark to list of apps banning GrapheneOS

### DIFF
--- a/static/articles/attestation-compatibility-guide.html
+++ b/static/articles/attestation-compatibility-guide.html
@@ -163,6 +163,7 @@
                     <li><a href="https://play.google.com/store/apps/details?id=de.tk.apps.android.tkident" rel="nofollow">TK-Ident</a></li>
                     <li><a href="https://play.google.com/store/apps/details?id=de.tk.tkapp" rel="nofollow">TK-App</a> (Blocks access to TK-Safe, TK-GesundheitsMessenger, fingerprint login)</li>
                     <li><a href="https://play.google.com/store/apps/details?id=it.pagopa.io.app" rel="nofollow">IO</a> (Italian government app which uses it to gate access to the digital wallet feature)</li>
+                    <li><a href="https://play.google.com/store/apps/details?id=net.easypark.android" rel="nofollow">EasyPark</a></li>
                     <li><a href="https://play.google.com/store/apps/details?id=posteitaliane.posteapp.appposteid" rel="nofollow">PosteID</a> (Italian postal service’s app used to access the national digital identity system "SPID")</li>
                     <li><a href="https://play.google.com/store/apps/details?id=sg.ndi.sp" rel="nofollow">Singpass</a></li>
                 </ul>


### PR DESCRIPTION
[EasyPark](https://play.google.com/store/apps/details?id=net.easypark.android) is a widely used parking payment app in Europe, particularly popular in Northern Italy and supported by nearly all the municipalities.

The Android app refuses to send the SMS OTP if the device fails Play Integrity checks.

I contacted appsupport@easypark.net and support@easypark.net requesting GrapheneOS support and linking the [Attestation Compatibility Guide](https://grapheneos.org/articles/attestation-compatibility-guide).

After several AI-generated responses, I received a human reply confirming that the app intentionally blocks ROMs that fail Play Integrity, including GrapheneOS, citing "security reasons":

<img width="1550" height="565" alt="image" src="https://github.com/user-attachments/assets/77cadfdb-d7c4-4f93-b383-fe71e868fcdc" />

Fun fact: obviously this is not a valid security measure, since it's possible to authenticate by requesting an OTP from the app (which will never arrive), then requesting one from the website and using it to authenticate in the app as if it were the code from the first request. However, I would consider this bypass as a vulnerability in EasyPark, so I would still recommend adding the app to the list of those that ban GrapheneOS.