### PR TITLE
Move Dialer link to standalone apps

### DIFF
--- a/static/source.html
+++ b/static/source.html
@@ -104,7 +104,6 @@
                     <li><a href="https://github.com/GrapheneOS/platform_packages_apps_CellBroadcastReceiver">platform_packages_apps_CellBroadcastReceiver</a></li>
                     <li><a href="https://github.com/GrapheneOS/platform_packages_apps_Contacts">platform_packages_apps_Contacts</a></li>
                     <li><a href="https://github.com/GrapheneOS/platform_packages_apps_DeskClock">platform_packages_apps_DeskClock</a></li>
-                    <li><a href="https://github.com/GrapheneOS/platform_packages_apps_Dialer">platform_packages_apps_Dialer</a></li>
                     <li><a href="https://github.com/GrapheneOS/platform_packages_apps_DocumentsUI">platform_packages_apps_DocumentsUI</a></li>
                     <li><a href="https://github.com/GrapheneOS/platform_packages_apps_EmergencyInfo">platform_packages_apps_EmergencyInfo</a></li>
                     <li><a href="https://github.com/GrapheneOS/platform_packages_apps_Gallery2">platform_packages_apps_Gallery2</a></li>
@@ -223,6 +222,7 @@
                     <li><a href="https://github.com/GrapheneOS/AppStore">App Store</a></li>
                     <li><a href="https://github.com/GrapheneOS/Auditor">Auditor</a></li>
                     <li><a href="https://github.com/GrapheneOS/Camera">Camera</a></li>
+                    <li><a href="https://github.com/GrapheneOS/platform_packages_apps_Dialer">Dialer</a></li>
                     <li><a href="https://github.com/GrapheneOS/Info">Info</a></li>
                     <li><a href="https://github.com/GrapheneOS/Messaging">Messaging</a></li>
                     <li><a href="https://github.com/GrapheneOS/PdfViewer">PDF Viewer</a></li>


### PR DESCRIPTION
I think the Dialer should be moved to the standalone apps section. There have been a number of [PRs ](https://github.com/GrapheneOS/platform_packages_apps_Dialer/pulls?q=is%3Apr) to improve the dialer beyond the AOSP version, including implementing call recording, improved call quality, bug fixes, theme updates, and Gradle migration attempts. Additionally, there are attempts to migrate the dialer to [material design 3](https://github.com/GrapheneOS/platform_packages_apps_Dialer/pull/54), further separating the app from the AOSP. 

By moving the Dialer app to the standalone app section, community involvement for the app should increase.