### PR TITLE
clarify cross-SIM calling enabling details

### DIFF
--- a/static/releases.html
+++ b/static/releases.html
@@ -663,7 +663,7 @@
 
                     <ul>
                         <li>raise declared Android security patch level to 2026-02-05 which has been provided since we moved to Android 16 QPR2 in December (was meant to be declared in the previous release)</li>
-                        <li>add cross-SIM calling support (making calls using a SIM via the mobile data provided by another SIM similarly to Wi-Fi calling)</li>
+                        <li>add cross-SIM calling support (making calls using a SIM via the mobile data provided by another SIM similarly to Wi-Fi calling); requires Automatic data switching in SIM settings, and existing installs may need to toggle Automatic data switching off and on to enable cross-SIM calling</li>
                         <li>extend our carrier override feature with a toggle for forcing the availability of cross-SIM calling support</li>
                     </ul>
 

--- a/static/usage.html
+++ b/static/usage.html
@@ -100,7 +100,13 @@
                     <li><a href="#android-auto">Android Auto</a></li>
                     <li><a href="#banking-apps">Banking apps</a></li>
                     <li><a href="#app-link-verification">App link verification</a></li>
-                    <li><a href="#carrier-functionality">Carrier functionality</a></li>
+                    <li>
+                        <a href="#carrier-functionality">Carrier functionality</a>
+                        <ul>
+                            <li><a href="#carrier-settings-overrides">Carrier settings overrides</a></li>
+                            <li><a href="#cross-sim-calling">Cross-SIM calling</a></li>
+                        </ul>
+                    </li>
                 </ul>
             </nav>
 
@@ -1422,6 +1428,30 @@
                 via USB, Ethernet, Bluetooth and Wi-Fi and the ability to disable 2G (only on 6th
                 generation Pixel devices onwards) actions which would not necessarily have been
                 possible on the stock operating system.</p>
+
+                <section id="carrier-settings-overrides">
+                    <h3><a href="#carrier-settings-overrides">Carrier settings overrides</a></h3>
+                    <p>GrapheneOS has support for overriding a subset of carrier settings such as 
+                    VoLTE, Wi-FI calling and cross-SIM calling availability. This is useful when 
+                    the stock OS has missing or incomplete configurations for some carriers. These 
+                    overrides are saved per SIM and can be configured under <b>Settings&#160;> 
+                    Network &amp; internet&#160;> SIMs&#160;> <var>SIM</var>&#160;> Carrier 
+                    settings overrides</b>.</p>
+                </section>
+
+                <section id="cross-sim-calling">
+                    <h3><a href="#cross-sim-calling">Cross-SIM calling</a></h3>
+                    <p>For dual SIM setups, GrapheneOS has support for cross-SIM calling (backup
+                    calling) which allows you to make calls using a SIM via the mobile data provided 
+                    by another SIM similarly to Wi-Fi calling. This requires Automatic data 
+                    switching to be enabled in <b>Settings&#160;> Network &amp; internet&#160;> SIMs
+                    </b>. This is useful when the primary SIM has no connectivity and you have a 
+                    second SIM with data, e.g. roaming outside of your country with a travel 
+                    eSIM.</p>
+                    
+                    <p>Cross-SIM calling is active when "Backup Calling" is added to the mobile 
+                    operator name.</p>
+                </section>
             </section>
         </main>
         {% include "footer.html" %}

--- a/static/usage.html
+++ b/static/usage.html
@@ -1184,7 +1184,7 @@
             </section>
 
             <section id="esim-management">
-                <h3><a href="#esim-management">eSIM management</a></h3>
+                <h2><a href="#esim-management">eSIM management</a></h2>
                 <p>By default, GrapheneOS has always shipped with baseline support for eSIM,
                 where users can use any eSIMs installed previously on the device. However, in
                 order to manage and add eSIMs, proprietary Google functionality is needed. This


### PR DESCRIPTION
Due to the upstream logic in
https://github.com/GrapheneOS/platform_packages_apps_Settings/blob/2026020600/src/com/android/settings/network/telephony/wificalling/CrossSimCallingViewModel.kt#L66, the Automatic data switching setting should be on. For existing installs, it might need to be  toggled off and on to enable cross-SIM calling.