### PR TITLE
fix typos in release notes referencing the wrong version numbers

### DIFF
--- a/static/releases.html
+++ b/static/releases.html
@@ -746,7 +746,7 @@
                         <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/2026030100">2026030100</a> (Pixel 6, Pixel 6 Pro, Pixel 6a, Pixel 7, Pixel 7 Pro, Pixel 7a, Pixel Tablet, Pixel Fold, Pixel 8, Pixel 8 Pro, Pixel 8a, Pixel 9, Pixel 9 Pro, Pixel 9 Pro XL, Pixel 9 Pro Fold, Pixel 9a, Pixel 10, Pixel 10 Pro, Pixel 10 Pro XL, Pixel 10 Pro Fold, emulator, generic, other targets)</li>
                     </ul>
 
-                    <p>Changes since the 2026020600 release:</p>
+                    <p>Changes since the 2026021200 release:</p>
 
                     <ul>
                         <li>SystemUI: migrate to the modern lockscreen infrastructure (smartspace) for showing lockscreen device status info to avoid many upstream bugs caused by AOSP still using the legacy lockscreen infrastructure no longer used on the stock Pixel OS (this allows us to revert a bunch of downstream fixes we were using)</li>
@@ -1197,7 +1197,7 @@
                         <li><a href="https://github.com/GrapheneOS/platform_manifest/releases/tag/2025120400">2025120400</a> (Pixel 6, Pixel 6 Pro, Pixel 6a, Pixel 7, Pixel 7 Pro, Pixel 7a, Pixel Tablet, Pixel Fold, Pixel 8, Pixel 8 Pro, Pixel 8a, Pixel 9, Pixel 9 Pro, Pixel 9 Pro XL, Pixel 9 Pro Fold, Pixel 9a, Pixel 10, Pixel 10 Pro, Pixel 10 Pro XL, Pixel 10 Pro Fold, emulator, generic, other targets)</li>
                     </ul>
 
-                    <p>Changes since the 2025111800 release:</p>
+                    <p>Changes since the 2025112100 release:</p>
 
                     <ul>
                         <li>full 2025-12-01 security patch level (has already been fully provided by our security preview releases for at least a month and most of the patches since September)</li>


### PR DESCRIPTION
I recently saw the typo in the 2026030100 release notes and found the second occurrence with this command:
```sh
grep -Eo "Changes since the .* release" static/releases.html | sort | uniq -c | sort -n | grep -v "1 Changes"
```