### PR TITLE
Add 'Voice of Hope' app to compatibility guide

### DIFF
--- a/static/articles/attestation-compatibility-guide.html
+++ b/static/articles/attestation-compatibility-guide.html
@@ -168,6 +168,7 @@
                     <li><a href="https://play.google.com/store/apps/details?id=net.easypark.android" rel="nofollow">EasyPark</a></li>
                     <li><a href="https://play.google.com/store/apps/details?id=posteitaliane.posteapp.appposteid" rel="nofollow">PosteID</a> (Italian postal service’s app used to access the national digital identity system "SPID")</li>
                     <li><a href="https://play.google.com/store/apps/details?id=sg.ndi.sp" rel="nofollow">Singpass</a></li>
+                    <li><a href="https://play.google.com/store/apps/details?id=com.voiceofhope.voh" rel="nofollow">Voice of Hope</a></li>
                 </ul>
 
                 <p>In addition to leaving feedback for these apps on the Play Store, file support


### PR DESCRIPTION
The app can not be installed from the Play Store. When downloading the apk manually, the installation is refused as well. 