### PR TITLE
Add 'no-shadow' rule to ESLint configuration

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -16,6 +16,7 @@ export default [
             sourceType: "module"
         },
         rules: {
+            "no-shadow": ["error"],
             "no-var": ["error"],
             "@stylistic/brace-style": ["error", "1tbs"],
             "@stylistic/indent": ["error", 4],

--- a/static/js/web-install.js
+++ b/static/js/web-install.js
@@ -161,7 +161,7 @@ class BlobStore {
         let blob = await this.loadFile(filename);
         if (blob === null) {
             console.log(`Downloading ${url}`);
-            let blob = await fetchBlobWithProgress(url, onProgress);
+            blob = await fetchBlobWithProgress(url, onProgress);
             console.log("File downloaded, saving...");
             await this.saveFile(filename, blob);
             console.log("File saved");


### PR DESCRIPTION
BlobStore.download() contained a `let` redeclaration of `blob` inside the `if (blob === null)` branch, shadowing the outer variable. This caused the method to return `null` when a file was freshly downloaded, rather than the downloaded Blob.

The current sole call site discards the return value, so there is no observable functional impact. However, the method's return value is incorrect and would silently fail if ever used by a caller expecting a Blob.

Fix: remove the `let` from the inner assignment so the outer variable is updated correctly before being returned.

Also add `"no-shadow": ["error"]` to eslint.config.js to catch this class of shadowing bug at lint time.

Changes:
- static/js/web-install.js: remove `let` redeclaration in BlobStore.download()
- eslint.config.js: add "no-shadow": ["error"]