### PR TITLE
replace deprecated lxml Element.getchildren()

### DIFF
--- a/generate-feed
+++ b/generate-feed
@@ -19,7 +19,7 @@ for release in releases[:20]:
         time = datetime.strptime(title, "%Y.%m.%d.%H").isoformat() + "Z"
     if updated is None:
         updated = time
-    content = [etree.tostring(e).decode() for e in release.getchildren()[1:]]
+    content = [etree.tostring(e).decode() for e in list(release)[1:]]
     entries.append(f"""
     <entry>
         <id>https://grapheneos.org/releases#{title}</id>


### PR DESCRIPTION
This pull request makes a minor update to how child elements are accessed in the `generate-feed` script

- Refactored the way child elements are retrieved from `release` by replacing the deprecated `getchildren()` method with `list(release)`