### PR TITLE
Remove eBay from Play Integrity API Blocklist

### DIFF
--- a/static/articles/attestation-compatibility-guide.html
+++ b/static/articles/attestation-compatibility-guide.html
@@ -203,7 +203,6 @@
                     <li><a href="https://play.google.com/store/apps/details?id=ch.ticketcorner.mobile.app.Android" rel="nofollow">Ticketcorner</a></li>
                     <li><a href="https://play.google.com/store/apps/details?id=com.authy.authy" rel="nofollow">Authy</a></li>
                     <li><a href="https://play.google.com/store/apps/details?id=com.chyrpe.chyrpe" rel="nofollow">Chyrpe Dating</a></li>
-                    <li><a href="https://play.google.com/store/apps/details?id=com.ebay.mobile" rel="nofollow">eBay</a></li>
                     <li><a href="https://play.google.com/store/apps/details?id=com.mada.madapay" rel="nofollow">mada Pay</a> (Saudi NFC payment app)</li>
                     <li><a href="https://play.google.com/store/apps/details?id=com.mcdonalds.mobileapp" rel="nofollow">McDonald's</a> (International app used for many but not all countries not including the US)</li>
                     <li><a href="https://play.google.com/store/apps/details?id=com.ridedott.rider" rel="nofollow">Dott</a></li>


### PR DESCRIPTION
Although you can't get the eBay app directly from the Play store, you can still download and install it from the Aurora Store and it works without any issues.