### PR TITLE
be more explicit: press unlock-bootloader button on installer page

### DIFF
--- a/static/install/web.html
+++ b/static/install/web.html
@@ -266,7 +266,8 @@
             <section id="unlocking-the-bootloader">
                 <h2><a href="#unlocking-the-bootloader">Unlocking the bootloader</a></h2>
 
-                <p>Unlock the bootloader to allow flashing the OS and firmware:</p>
+                <p>Press the button below to unlock the bootloader, which enables flashing
+                the OS and firmware:</p>
 
                 <button id="unlock-bootloader-button" disabled="">Unlock bootloader</button>
 


### PR DESCRIPTION
Be especially explicit about the first button users must press on the web installer UI, since users don't always recognize the buttons as buttons, and may think that the process should be kicked off by taking some action on the device being flashed.

Example: https://discuss.grapheneos.org/d/35480/7.