### PR TITLE
Feature/add link

### DIFF
--- a/static/articles/index.html
+++ b/static/articles/index.html
@@ -44,6 +44,7 @@
                 <li><a href="/build">Build</a> — Building instructions for GrapheneOS.</li>
                 <li><a href="/usage">Usage guide</a> — Usage instructions for GrapheneOS.</li>
                 <li><a href="/faq">Frequently Asked Questions</a> — Answers to frequently asked questions about GrapheneOS.</li>
+                <li><a href="https://devdude437.github.io/App-Compatibility-without-Google-Play-Services">App Compatibility Website</a> - A website of apps tested that work without Google Play Services.</li>
                 <li><a href="/releases#changelog">Releases changelog</a> — Changelog for official releases of GrapheneOS.</li>
                 <li><a href="/source">Source code</a> — Documenting all source code repositories for GrapheneOS.</li>
                 <li><a href="/history/">History</a> — History of the GrapheneOS project.</li>

--- a/static/articles/index.html
+++ b/static/articles/index.html
@@ -44,7 +44,7 @@
                 <li><a href="/build">Build</a> — Building instructions for GrapheneOS.</li>
                 <li><a href="/usage">Usage guide</a> — Usage instructions for GrapheneOS.</li>
                 <li><a href="/faq">Frequently Asked Questions</a> — Answers to frequently asked questions about GrapheneOS.</li>
-                <li><a href="https://devdude437.github.io/App-Compatibility-without-Google-Play-Services">App Compatibility Website</a> - A website of apps tested that work without Google Play Services.</li>
+                <li><a href="https://devdude437.github.io/App-Compatibility-without-Google-Play-Services">App Compatibility Website</a> - A website of proprietary apps tested that work without Google Play Services.</li>
                 <li><a href="/releases#changelog">Releases changelog</a> — Changelog for official releases of GrapheneOS.</li>
                 <li><a href="/source">Source code</a> — Documenting all source code repositories for GrapheneOS.</li>
                 <li><a href="/history/">History</a> — History of the GrapheneOS project.</li>


### PR DESCRIPTION
This PR adds a link to my [website](https://devdude437.github.io/App-Compatibility-without-Google-Play-Services/). This website is a maintained list of proprietary apps that work without Google Play Services. I feel this would be beneficial to new users exploring the GrapheneOS website. You can view the repository for my website [here](https://github.com/DevDude437/App-Compatibility-without-Google-Play-Services). I think this would be a very useful link to the website to help new users.

EDIT: Issue with website being broken has been resolved.