### PR TITLE
mention Mali GPU driver in Samsung heap driver fix

### DIFF
--- a/static/releases.html
+++ b/static/releases.html
@@ -666,7 +666,7 @@
                         <li>kernel (6.1): update to latest GKI LTS branch revision including update to 6.1.173</li>
                         <li>kernel (6.6): update to latest GKI LTS branch revision including update to 6.6.139</li>
                         <li>kernel (6.12): update to latest GKI LTS branch revision including update to 6.12.88</li>
-                        <li>kernel (Pixel): fix upstream bug in Samsung TEE DMA heap driver used by the PowerVR GPU driver for DRM support</li>
+                        <li>kernel (Pixel): fix upstream bug in Samsung TEE DMA heap driver used by the PowerVR and Mali GPU drivers for DRM support</li>
                         <li>Vanadium: update to <a href="https://github.com/GrapheneOS/Vanadium/releases/tag/148.0.7778.167.0">version 148.0.7778.167.0</a></li>
                         <li>Vanadium: update to <a href="https://github.com/GrapheneOS/Vanadium/releases/tag/148.0.7778.178.0">version 148.0.7778.178.0</a></li>
                         <li>Vanadium: update to <a href="https://github.com/GrapheneOS/Vanadium/releases/tag/149.0.7827.22.0">version 149.0.7827.22.0</a></li>


### PR DESCRIPTION
On shiba, the panic can come from a task called `mali-mem-purge`