### PR TITLE
Add BKK Faber-Castell app

### DIFF
--- a/static/articles/attestation-compatibility-guide.html
+++ b/static/articles/attestation-compatibility-guide.html
@@ -207,7 +207,7 @@
                     <li><a href="https://play.google.com/store/apps/details?id=com.mcdonalds.mobileapp" rel="nofollow">McDonald's</a> (International app used for many but not all countries not including the US)</li>
                     <li><a href="https://play.google.com/store/apps/details?id=com.ridedott.rider" rel="nofollow">Dott</a></li>
                     <li><a href="https://play.google.com/store/apps/details?id=com.swisssign.swissid.mobile" rel="nofollow">SwissID</a></li>
-                    <li><a href="https://play.google.com/store/apps/details?id=de.bkkfabercastell.app" rel="nofollow">BKK Faber-Castell & Partner</a></li>
+                    <li><a href="https://play.google.com/store/apps/details?id=de.bkkfabercastell.app" rel="nofollow">BKK Faber-Castell &amp; Partner</a></li>
                     <li><a href="https://play.google.com/store/apps/details?id=de.telearzt.tkchat" rel="nofollow">TK-Doc</a></li>
                     <li><a href="https://play.google.com/store/apps/details?id=de.tk.apps.android.tkident" rel="nofollow">TK-Ident</a></li>
                     <li><a href="https://play.google.com/store/apps/details?id=de.tk.tkapp" rel="nofollow">TK-App</a> (Blocks access to TK-Safe, TK-GesundheitsMessenger, fingerprint login)</li>

--- a/static/articles/attestation-compatibility-guide.html
+++ b/static/articles/attestation-compatibility-guide.html
@@ -207,6 +207,7 @@
                     <li><a href="https://play.google.com/store/apps/details?id=com.mcdonalds.mobileapp" rel="nofollow">McDonald's</a> (International app used for many but not all countries not including the US)</li>
                     <li><a href="https://play.google.com/store/apps/details?id=com.ridedott.rider" rel="nofollow">Dott</a></li>
                     <li><a href="https://play.google.com/store/apps/details?id=com.swisssign.swissid.mobile" rel="nofollow">SwissID</a></li>
+                    <li><a href="https://play.google.com/store/apps/details?id=de.bkkfabercastell.app" rel="nofollow">BKK Faber-Castell & Partner</a></li>
                     <li><a href="https://play.google.com/store/apps/details?id=de.telearzt.tkchat" rel="nofollow">TK-Doc</a></li>
                     <li><a href="https://play.google.com/store/apps/details?id=de.tk.apps.android.tkident" rel="nofollow">TK-Ident</a></li>
                     <li><a href="https://play.google.com/store/apps/details?id=de.tk.tkapp" rel="nofollow">TK-App</a> (Blocks access to TK-Safe, TK-GesundheitsMessenger, fingerprint login)</li>


### PR DESCRIPTION
App start fails with technical error; numerous attempts to use the Play Integrity API are shown.

<img width="400" height="496" alt="screenshot of error message" src="https://github.com/user-attachments/assets/5b6f7316-14aa-4e34-a294-9d16aad3dc03" />
