### PR TITLE
UI Wizard

### DIFF
--- a/static/css/wizard.css
+++ b/static/css/wizard.css
@@ -3,12 +3,12 @@
     display: none;
 }
 
-/* When Classic Mode is active */
+/* When Classic mode is active */
 #web-install.classic-mode .classic-view-content {
     display: block;
 }
 
-/* When wizard mode is activ */
+/* When Wizard mode is activ */
 #web-install.wizard-mode .classic-view-content {
     display: none; 
 }
@@ -56,9 +56,9 @@
     border-bottom: 3px solid #4a90e2;
 }
 
-/* Card styles */
+/* Card Styles */
 .wizard-card {
-    display: none; /* Hidden by default */
+    display: none; /* Hidden by default via JS state management */
     background: #2a2a2a;
     border: 1px solid #424242;
     border-radius: 12px;
@@ -179,6 +179,7 @@
         opacity: 0;
         transform: translateY(10px);
     }
+
     to {
         opacity: 1;
         transform: translateY(0);

--- a/static/css/wizard.css
+++ b/static/css/wizard.css
@@ -8,7 +8,7 @@
     display: block;
 }
 
-/* When Wizard mode is activ */
+/* When wizard mode is activ */
 #web-install.wizard-mode .classic-view-content {
     display: none; 
 }
@@ -22,7 +22,7 @@
     display: flex;
     list-style: none;
     padding: 0;
-    margin: 0 0 2rem 0;
+    margin: 0 0 2rem;
     background: #1a1a1a;
     border-radius: 8px;
     overflow: hidden;
@@ -64,12 +64,12 @@
     border-radius: 12px;
     padding: 2.5rem;
     margin: 1.5rem 0;
-    box-shadow: 0 4px 12px rgba(0,0,0,0.3);
+    box-shadow: 0 4px 12px rgb(0 0 0 / 30%);
 }
 
 .wizard-card.active {
     display: block;
-    animation: fadeIn 0.4s ease;
+    animation: fade-in 0.4s ease;
 }
 
 .wizard-subtitle {
@@ -174,7 +174,13 @@
     background: #555;
 }
 
-@keyframes fadeIn {
-    from { opacity: 0; transform: translateY(10px); }
-    to { opacity: 1; transform: translateY(0); }
+@keyframes fade-in {
+    from {
+        opacity: 0;
+        transform: translateY(10px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
 }

--- a/static/css/wizard.css
+++ b/static/css/wizard.css
@@ -1,0 +1,180 @@
+/* Hide wizard elements initially */
+.wizard-view-content {
+    display: none;
+}
+
+/* When Classic Mode is active */
+#web-install.classic-mode .classic-view-content {
+    display: block;
+}
+
+/* When Wizard mode is activ */
+#web-install.wizard-mode .classic-view-content {
+    display: none; 
+}
+
+#web-install.wizard-mode .wizard-view-content {
+    display: block;
+}
+
+/* Breadcrumb styles */
+.wizard-breadcrumbs {
+    display: flex;
+    list-style: none;
+    padding: 0;
+    margin: 0 0 2rem 0;
+    background: #1a1a1a;
+    border-radius: 8px;
+    overflow: hidden;
+    border: 1px solid #333;
+}
+
+.wizard-breadcrumbs li {
+    flex: 1;
+    text-align: center;
+    padding: 1rem 0.5rem;
+    font-size: 0.9rem;
+    color: #666;
+    background: #222;
+    border-right: 1px solid #333;
+    transition: all 0.3s ease;
+}
+
+.wizard-breadcrumbs li:last-child {
+    border-right: none;
+}
+
+.wizard-breadcrumbs li.completed {
+    color: #4a90e2;
+    background: #1a1a1a;
+}
+
+.wizard-breadcrumbs li.active {
+    color: #fff;
+    background: #2a2a2a;
+    font-weight: bold;
+    border-bottom: 3px solid #4a90e2;
+}
+
+/* Card styles */
+.wizard-card {
+    display: none; /* Hidden by default */
+    background: #2a2a2a;
+    border: 1px solid #424242;
+    border-radius: 12px;
+    padding: 2.5rem;
+    margin: 1.5rem 0;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.3);
+}
+
+.wizard-card.active {
+    display: block;
+    animation: fadeIn 0.4s ease;
+}
+
+.wizard-subtitle {
+    color: #aaa;
+    margin-bottom: 1.5rem;
+    font-size: 1.05rem;
+}
+
+/* Content specific styles */
+.wizard-checklist, .wizard-instructions {
+    list-style: none;
+    padding: 0;
+    margin-bottom: 2rem;
+}
+
+.wizard-instructions {
+    list-style: decimal inside;
+}
+
+.wizard-instructions li,
+.wizard-instructions p {
+    padding: 0.8rem 0;
+    font-size: 1.05rem;
+    border-bottom: 1px solid #383838;
+}
+
+.wizard-instructions li:last-child,
+.wizard-instructions p:last-child {
+    border-bottom: none;
+}
+
+.wizard-checklist li {
+    padding: 1.2rem;
+    border-bottom: 1px solid #383838;
+    display: flex;
+    align-items: flex-start;
+}
+
+.wizard-checklist input[type="checkbox"] {
+    width: 22px;
+    height: 22px;
+    margin-right: 15px;
+    margin-top: 2px;
+    cursor: pointer;
+}
+
+/* Containers injected via JS */
+.interactive-container {
+    padding: 1.5rem;
+    background: #1e1e1e;
+    border-radius: 6px;
+    margin: 1rem 0;
+    text-align: center;
+}
+
+/* Buttons */
+.mode-selection-banner {
+    background-color: #1a1a1a;
+    border: 1px dashed #4a90e2;
+    padding: 1.5rem;
+    border-radius: 8px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 2rem;
+}
+
+.wizard-nav-actions {
+    display: flex;
+    justify-content: space-between;
+    margin-top: 2rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid #424242;
+}
+
+.btn-wizard-primary, .btn-wizard-secondary {
+    padding: 0.8rem 1.5rem;
+    border-radius: 6px;
+    font-weight: bold;
+    cursor: pointer;
+    border: none;
+    font-size: 1rem;
+}
+
+.btn-wizard-primary {
+    background: #4a90e2;
+    color: white;
+}
+
+.btn-wizard-primary:disabled {
+    background: #444;
+    color: #888;
+    cursor: not-allowed;
+}
+
+.btn-wizard-secondary {
+    background: #444;
+    color: #ddd;
+}
+
+.btn-wizard-secondary:hover {
+    background: #555;
+}
+
+@keyframes fadeIn {
+    from { opacity: 0; transform: translateY(10px); }
+    to { opacity: 1; transform: translateY(0); }
+}

--- a/static/install/web.html
+++ b/static/install/web.html
@@ -25,430 +25,576 @@
         <link rel="mask-icon" href="[[path|/mask-icon.svg]]" color="#1a1a1a"/>
         <link rel="apple-touch-icon" href="/apple-touch-icon.png"/>
         [[css|/main.css]]
+        [[css|/css/wizard.css]]
         <link rel="manifest" href="/manifest.webmanifest"/>
         <link rel="license" href="/LICENSE.txt"/>
         <link rel="me" href="https://grapheneos.social/@GrapheneOS"/>
         [[js|/js/redirect.js]]
         <script type="module" src="/js/fastboot/ffe7e270/fastboot.min.mjs" integrity="sha256-/TM74wkIOUV1rXRSGlzJPb4ZjBA52fzUW3aSypxxtwc="></script>
         [[js|/js/web-install.js]]
+        [[js|/js/wizard.js]]
     </head>
     <body>
         {% include "header.html" %}
-        <main id="web-install">
-            <h1><a href="#web-install">Web installer</a></h1>
-
-            <p>This is the WebUSB-based installer for GrapheneOS and is the recommended approach
-            for most users. The <a href="/install/cli">command-line installation guide</a> is the
-            more traditional approach to installing GrapheneOS.</p>
-
-            <p>If you have trouble with the installation process, ask for help on the
-            <a href="/contact#community">official GrapheneOS chat channel</a>. There are almost
-            always people around willing to help with it. Before asking for help, make an attempt
-            to follow the guide on your own and then ask for help with anything you get stuck
-            on.</p>
-
-            <nav id="table-of-contents">
-                <h2><a href="#table-of-contents">Table of contents</a></h2>
-
-                <ul>
-                    <li><a href="#prerequisites">Prerequisites</a></li>
-                    <li><a href="#enabling-oem-unlocking">Enabling OEM unlocking</a></li>
-                    <li><a href="#flashing-as-non-root">Flashing as non-root</a></li>
-                    <li><a href="#working-around-fwupd-bugs-on-linux-distributions">Working around fwupd bugs on Linux distributions</a></li>
-                    <li><a href="#booting-into-the-bootloader-interface">Booting into the bootloader interface</a></li>
-                    <li><a href="#connecting-device">Connecting the device</a></li>
-                    <li><a href="#unlocking-the-bootloader">Unlocking the bootloader</a></li>
-                    <li><a href="#obtaining-factory-images">Obtaining factory images</a></li>
-                    <li><a href="#flashing-factory-images">Flashing factory images</a></li>
-                    <li><a href="#locking-the-bootloader">Locking the bootloader</a></li>
-                    <li>
-                        <a href="#post-installation">Post-installation</a>
-                        <ul>
-                            <li><a href="#booting">Booting</a></li>
-                            <li><a href="#disabling-oem-unlocking">Disabling OEM unlocking</a></li>
-                            <li>
-                                <a href="#verifying-installation">Verifying installation</a>
-                                <ul>
-                                    <li><a href="#verified-boot-key-hash">Verified boot key hash</a></li>
-                                    <li><a href="#hardware-based-attestation">Hardware-based attestation</a></li>
-                                </ul>
-                            </li>
-                            <li><a href="#further-information">Further information</a></li>
-                            <li><a href="#replacing-grapheneos-with-the-stock-os">Replacing GrapheneOS with the stock OS</a></li>
-                        </ul>
-                    </li>
-                </ul>
-            </nav>
-
-            <section id="prerequisites">
-                <h2><a href="#prerequisites">Prerequisites</a></h2>
-
-                <p>You need a computer for running the web installer with at least 2GB of free
-                memory available and 32GB of free storage space. The web installer can be run on an
-                Android phone or tablet, unlike the command-line installation.</p>
-
-                <p>You need a USB cable for attaching the device to the computer performing the
-                installation. Whenever possible, use the high quality standards compliant USB-C
-                cable packaged with the device. If your computer doesn't have any USB-C ports,
-                you'll need a high quality USB-C to USB-A cable. You should avoid using a USB hub
-                such as the front panel on a desktop computer case. Connect directly to a rear port
-                on a desktop or the ports on a laptop. Many widely distributed USB cables and hubs
-                are broken and are the most common source of issues for installing GrapheneOS.</p>
-
-                <p>Installing from an OS in a virtual machine is not recommended. USB passthrough
-                is often not reliable. To rule out these problems, install from an OS running on
-                bare metal. Virtual machines are also often configured to have overly limited
-                memory and storage space.</p>
-
-                <p>Officially supported operating systems for the web install method:</p>
-
-                <ul>
-                    <li>Windows 10</li>
-                    <li>Windows 11</li>
-                    <li>macOS Sonoma (14)</li>
-                    <li>macOS Sequoia (15)</li>
-                    <li>macOS Tahoe (26)</li>
-                    <li>Arch Linux</li>
-                    <li>Debian 12 (bookworm)</li>
-                    <li>Debian 13 (trixie)</li>
-                    <li>Ubuntu 22.04 LTS</li>
-                    <li>Ubuntu 24.04 LTS</li>
-                    <li>Ubuntu 25.04</li>
-                    <li>Linux Mint 21 (follow Ubuntu 22.04 LTS instructions)</li>
-                    <li>Linux Mint 22 (follow Ubuntu 24.04 LTS instructions)</li>
-                    <li>Linux Mint Debian Edition 6 (follow Debian 12 instructions)</li>
-                    <li>ChromeOS</li>
-                    <li>GrapheneOS</li>
-                    <li>Android 13 with Play Protect certification</li>
-                    <li>Android 14 with Play Protect certification</li>
-                    <li>Android 15 with Play Protect certification</li>
-                    <li>Android 16 with Play Protect certification</li>
-                </ul>
-
-                <p>Older end-of-life versions of these platforms can also be used but are not
-                officially supported.</p>
-
-                <p>Make sure your operating system is up-to-date before proceeding.</p>
-
-                <p>Officially supported browsers for the web install method:</p>
-
-                <ul>
-                    <li>Chromium (outside Ubuntu, since they ship a broken Snap package without working WebUSB)</li>
-                    <li>Vanadium (GrapheneOS)</li>
-                    <li>Google Chrome</li>
-                    <li>Microsoft Edge</li>
-                    <li>Brave (with Brave Shields disabled, since it caps storage usage at a low value to avoid fingerprinting available storage)</li>
-                </ul>
-
-                <p>On Android, disable desktop mode for the browser since it currently prevents our
-                web installer from detecting Android and handling needing to request permission to
-                reconnect to the device after each reboot. Desktop mode is enabled by default on
-                large tablets with at least 8GB of RAM such as the Pixel Tablet.</p>
-
-                <p>You should avoid Flatpak and Snap versions of browsers, as they're known to cause issues during the installation process.</p>
-
-                <p>Make sure your browser is up-to-date before proceeding.</p>
-
-                <p>Do not use Incognito or other private browsing modes. These modes usually
-                prevent the web installer from having enough storage space to extract the
-                downloaded release.</p>
-
-                <p>You need one of the <a href="/faq#supported-devices">officially supported
-                devices</a>. To make sure that the device can be unlocked to install GrapheneOS,
-                avoid carrier variants of the devices. Carrier variants of Pixels use the same stock
-                OS and firmware with a non-zero carrier id flashed onto the persist partition in the
-                factory. The carrier id activates carrier-specific configuration in the stock OS
-                including disabling carrier and bootloader unlocking. The carrier may be able to
-                remotely disable this, but their support staff may not be aware and they probably
-                won't do it. Get a carrier agnostic device to avoid the risk and potential hassle.
-                If you CAN figure out a way to unlock a carrier device, it isn't a problem as
-                GrapheneOS can just ignore the carrier id and the hardware is the same.</p>
-
-                <p>It's best practice to update the device before installing GrapheneOS to have
-                the latest firmware for connecting the device to the computer and performing the
-                early flashing process. Either way, GrapheneOS flashes the latest firmware early
-                in the installation process.</p>
-            </section>
-
-            <section id="enabling-oem-unlocking">
-                <h2><a href="#enabling-oem-unlocking">Enabling OEM unlocking</a></h2>
-
-                <p>OEM unlocking needs to be enabled from within the operating system.</p>
-
-                <p>Enable the developer options menu by going to <b>Settings&#160;> About phone/tablet</b> and repeatedly
-                pressing the <b>Build number</b> menu entry until developer mode is enabled.</p>
-
-                <p>Next, go to <b>Settings&#160;>
-                System&#160;> Developer options</b> and
-                toggle on the <b>OEM unlocking</b> setting. On device model variants (SKUs) which
-                support being sold as locked devices by carriers, enabling <b>OEM unlocking</b>
-                requires internet access so that the stock OS can check if the device was sold as
-                locked by a carrier.</p>
-
-                <p>For the Pixel 6a, OEM unlocking won't work with the version of the stock OS
-                from the factory. You need to update it to the June 2022 release or later via an
-                over-the-air update. After you've updated it you'll also need to factory reset
-                the device to fix OEM unlocking.</p>
-            </section>
-
-            <section id="flashing-as-non-root">
-                <h2><a href="#flashing-as-non-root">Flashing as non-root</a></h2>
-
-                <p>On traditional Linux distributions, USB devices cannot be used as non-root
-                without udev rules for each type of device. This is not an issue for other
-                platforms.</p>
-
-                <p>On Arch Linux, install the <code>android-udev</code> package. On Debian and
-                Ubuntu, install the <code>android-sdk-platform-tools-common</code> package.</p>
-            </section>
-
-            <section id="working-around-fwupd-bugs-on-linux-distributions">
-                <h2><a href="#working-around-fwupd-bug-on-linux-distributions">Working around fwupd bugs on Linux distributions</a></h2>
-
-                <p>The fwupd software often used on Linux distributions for updating firmware is
-                known to incorrectly connect to arbitrary devices using the fastboot protocol which
-                will block using them for the intended purpose. This can result in receiving an
-                error about the USB device already being in use (claimed) when trying to connect to
-                it for the intended purpose.</p>
-
-                <p>You can stop fwupd with the following command:</p>
-
-                <pre>sudo systemctl stop fwupd.service</pre>
-
-                <p>This doesn't disable the service and it will start again on reboot.</p>
-            </section>
-
-            <section id="booting-into-the-bootloader-interface">
-                <h2><a href="#booting-into-the-bootloader-interface">Booting into the bootloader interface</a></h2>
-
-                <p>You need to boot your device into the bootloader interface. To do this, you need
-                to hold the volume down button while the device boots.</p>
-
-                <p>The easiest approach is to reboot the device and begin holding the volume down
-                button until it boots up into the bootloader interface.</p>
-
-                <p>Alternatively, turn off the device, then boot it up while holding the volume
-                down button during the boot process. You can either boot it with the power button
-                or by plugging it in as required in the next section.</p>
-
-                <p>This step is not complete until your device displays a red warning triangle
-                and the words "Fastboot Mode".  You must not press the device's power button
-                to activate the "Start" menu item, because the device must remain paused in
-                Fastboot mode for the installer to connect to it.</p>
-            </section>
-
-            <section id="connecting-device">
-                <h2><a href="#connecting-device">Connecting the device</a></h2>
-
-                <p>Connect the device to the computer. On Linux, you'll need to do this again if
-                you didn't have the udev rules set up when you connected it.</p>
-
-                <p>Current Windows 10 and Windows 11 include a generic driver usable for fastboot
-                and no longer require installing a driver for installation on the Pixel 4a (5G) or
-                later. It isn't enough for legacy 4th generation Pixels due to the driver not
-                handling fastbootd, so you still need the driver for those. Outdated Windows
-                versions will still need the driver for non-obsolete devices too. You can obtain the
-                driver from Windows Update which will detect it as an optional update when the
-                device is booted into the bootloader interface and connected to the computer. Open
-                Windows Update, run a check for updates and then open the "View optional updates"
-                interface. Install the driver for the Android bootloader interface as an optional
-                update, which will show up as "LeMobile Android Device" due to USB ID overlap. An
-                alternative approach to obtaining the Windows fastboot driver is to obtain the <a
-                href="https://developer.android.com/studio/run/win-usb">latest driver for
-                Pixels</a> from Google and then <a href="https://developer.android.com/studio/run/oem-usb#InstallingDriver">manually
-                install it with the Windows Device Manager</a>.</p>
-
-                <p>For the Pixel Tablet, disconnect it from the stand before continuing. The stand
-                uses USB to provide charging and audio output, but the tablet lacks support for
-                using both the stand and USB port at the same time.</p>
-            </section>
-
-            <section id="unlocking-the-bootloader">
-                <h2><a href="#unlocking-the-bootloader">Unlocking the bootloader</a></h2>
-
-                <p>Press the button below to unlock the bootloader, which enables flashing
-                the OS and firmware:</p>
-
-                <button id="unlock-bootloader-button" disabled="">Unlock bootloader</button>
-
-                <p>The command needs to be confirmed on the device and will wipe all data. Use one
-                of the volume buttons to switch the selection to accepting it and the power button to
-                confirm.</p>
-
-                <p><strong id="unlock-bootloader-status"></strong></p>
-            </section>
-
-            <section id="obtaining-factory-images">
-                <h2><a href="#obtaining-factory-images">Obtaining factory images</a></h2>
-
-                <p>You need to obtain the GrapheneOS factory images for your device to proceed with
-                the installation process.</p>
-
-                <p>Press the button below to start the download:</p>
-
-                <p><strong id="quota-warning-text" class="warning-text" hidden="hidden">Warning: browser
-                is reporting a low storage quota, there might not be enough space for the image</strong></p>
-
-                <button id="download-release-button" disabled="">Download release</button>
-
-                <p id="download-release-status-container" hidden="hidden">
-                    <strong id="download-release-status"></strong>
-                    <br/>
-                    <progress id="download-release-progress" hidden="hidden" max="1" value="0"></progress>
-                </p>
-            </section>
-
-            <section id="flashing-factory-images">
-                <h2><a href="#flashing-factory-images">Flashing factory images</a></h2>
-
-                <p>The initial install will be performed by flashing the factory images. This will
-                replace the existing OS installation and wipe all the existing data.</p>
-
-                <button id="flash-release-button" disabled="">Flash release</button>
-
-
-                <p>Wait for the flashing process to complete. It will automatically handle
-                flashing the firmware, rebooting into the bootloader interface and flashing the OS.
-                Avoid interacting with the device until the flashing script is finished. Then,
-                proceed to <a href="#locking-the-bootloader">locking the bootloader</a> before using
-                the device as locking wipes the data again.</p>
-
-                <p id="flash-release-status-container" hidden="hidden">
-                    <strong id="flash-release-status"></strong>
-                    <br/>
-
-                    <!-- These appear as part of the status, one at a time -->
-                    <progress id="flash-release-progress" hidden="hidden" max="1" value="0"></progress>
-                    <button id="flash-reconnect-button" hidden="hidden"><strong>Reconnect device</strong></button>
-                </p>
-            </section>
-
-            <section id="locking-the-bootloader">
-                <h2><a href="#locking-the-bootloader">Locking the bootloader</a></h2>
-
-                <p>Locking the bootloader is important as it enables full verified boot. It also
-                prevents using fastboot to flash, format or erase partitions.  Verified boot will
-                detect modifications to any of the OS partitions and it will prevent reading any
-                modified or corrupted data. If changes are detected, error correction data is used
-                to attempt to obtain the original data at which point it's verified again which
-                makes verified boot robust to non-malicious corruption.</p>
-
-                <p>In the bootloader interface, set it to locked:</p>
-
-                <button id="lock-bootloader-button" disabled="">Lock bootloader</button>
-
-                <p>The command needs to be confirmed on the device and will wipe all data. Use one
-                of the volume buttons to switch the selection to accepting it and the power button
-                to confirm.</p>
-
-                <p><strong id="lock-bootloader-status"></strong></p>
-            </section>
-
-            <section id="post-installation">
-                <h2><a href="#post-installation">Post-installation</a></h2>
-
-                <section id="booting">
-                    <h3><a href="#booting">Booting</a></h3>
-
-                    <p>You've now successfully installed GrapheneOS and can boot it. Pressing the
-                    power button with the default Start option selected in the bootloader
-                    interface will boot the OS.</p>
+        <main id="web-install" class="classic-mode">
+            
+            <div class="mode-selection-banner">
+                <p>Try our step-by-step interactive guide.</p>
+                <button id="toggle-wizard-btn" class="btn-wizard-toggle">Enable Guided Wizard</button>
+            </div>
+
+            <div class="classic-view-content">
+                <h1><a href="#web-install">Web installer</a></h1>
+
+                <p>This is the WebUSB-based installer for GrapheneOS and is the recommended approach
+                for most users. The <a href="/install/cli">command-line installation guide</a> is the
+                more traditional approach to installing GrapheneOS.</p>
+
+                <p>If you have trouble with the installation process after following this guide, ask for help on the
+                <a href="/contact#community">official GrapheneOS chat channel</a></p>
+
+                <nav id="table-of-contents">
+                    <h2><a href="#table-of-contents">Table of contents</a></h2>
+
+                    <ul>
+                        <li><a href="#prerequisites">Prerequisites</a></li>
+                        <li><a href="#enabling-oem-unlocking">Enabling OEM unlocking</a></li>
+                        <li><a href="#flashing-as-non-root">Flashing as non-root</a></li>
+                        <li><a href="#working-around-fwupd-bugs-on-linux-distributions">Working around fwupd bugs on Linux distributions</a></li>
+                        <li><a href="#booting-into-the-bootloader-interface">Booting into the bootloader interface</a></li>
+                        <li><a href="#connecting-device">Connecting the device</a></li>
+                        <li><a href="#unlocking-the-bootloader">Unlocking the bootloader</a></li>
+                        <li><a href="#obtaining-factory-images">Obtaining factory images</a></li>
+                        <li><a href="#flashing-factory-images">Flashing factory images</a></li>
+                        <li><a href="#locking-the-bootloader">Locking the bootloader</a></li>
+                        <li>
+                            <a href="#post-installation">Post-installation</a>
+                            <ul>
+                                <li><a href="#booting">Booting</a></li>
+                                <li><a href="#disabling-oem-unlocking">Disabling OEM unlocking</a></li>
+                                <li>
+                                    <a href="#verifying-installation">Verifying installation</a>
+                                    <ul>
+                                        <li><a href="#verified-boot-key-hash">Verified boot key hash</a></li>
+                                        <li><a href="#hardware-based-attestation">Hardware-based attestation</a></li>
+                                    </ul>
+                                </li>
+                                <li><a href="#further-information">Further information</a></li>
+                                <li><a href="#replacing-grapheneos-with-the-stock-os">Replacing GrapheneOS with the stock OS</a></li>
+                            </ul>
+                        </li>
+                    </ul>
+                </nav>
+
+                <section id="prerequisites">
+                    <h2><a href="#prerequisites">Prerequisites</a></h2>
+
+                    <p>You need a computer for running the web installer with at least 2GB of free
+                    memory available and 32GB of free storage space. The web installer can be run on an
+                    Android phone or tablet, unlike the command-line installation.</p>
+
+                    <p>You need a USB cable for attaching the device to the computer. 
+                    Preferably, use the high quality standards compliant USB-C
+                    cable packaged with the device. You should avoid using a USB hub
+                    such as the front panel on a desktop computer case. Connect directly to a rear port
+                    on a desktop or the ports on a laptop. Many widely distributed USB cables and hubs
+                    are broken and are the most common source of issues for installing GrapheneOS.</p>
+
+                    <p>Installing from an OS in a virtual machine is not recommended.</p>
+
+                    <p>Officially supported operating systems for the web install method:</p>
+
+                    <ul>
+                        <li>Windows 10</li>
+                        <li>Windows 11</li>
+                        <li>macOS Sonoma (14)</li>
+                        <li>macOS Sequoia (15)</li>
+                        <li>macOS Tahoe (26)</li>
+                        <li>Arch Linux</li>
+                        <li>Debian 12 (bookworm)</li>
+                        <li>Debian 13 (trixie)</li>
+                        <li>Ubuntu 22.04 LTS</li>
+                        <li>Ubuntu 24.04 LTS</li>
+                        <li>Ubuntu 25.04</li>
+                        <li>Linux Mint 21 (follow Ubuntu 22.04 LTS instructions)</li>
+                        <li>Linux Mint 22 (follow Ubuntu 24.04 LTS instructions)</li>
+                        <li>Linux Mint Debian Edition 6 (follow Debian 12 instructions)</li>
+                        <li>ChromeOS</li>
+                        <li>GrapheneOS</li>
+                        <li>Android 13 with Play Protect certification</li>
+                        <li>Android 14 with Play Protect certification</li>
+                        <li>Android 15 with Play Protect certification</li>
+                        <li>Android 16 with Play Protect certification</li>
+                    </ul>
+
+                    <p>Older end-of-life versions of these platforms can also be used but are not
+                    officially supported.</p>
+
+                    <p>Make sure your operating system is up-to-date before proceeding.</p>
+
+                    <p>Officially supported browsers for the web install method:</p>
+
+                    <ul>
+                        <li>Chromium (outside Ubuntu, since they ship a broken Snap package without working WebUSB)</li>
+                        <li>Vanadium (GrapheneOS)</li>
+                        <li>Google Chrome</li>
+                        <li>Microsoft Edge</li>
+                        <li>Brave (with Brave Shields disabled, since it caps storage usage at a low value to avoid fingerprinting available storage)</li>
+                    </ul>
+
+                    <p>On Android, disable desktop mode for the browser. Desktop mode is enabled by default on
+                    large tablets with at least 8GB of RAM such as the Pixel Tablet.</p>
+
+                    <p>You should avoid Flatpak and Snap versions of browsers, as they're known to cause issues during the installation process.</p>
+
+                    <p>Make sure your browser is up-to-date before proceeding.</p>
+
+                    <p>Do not use Incognito or other private browsing modes. These modes usually
+                    prevent the web installer from having enough storage space to extract the
+                    downloaded release.</p>
+
+                    <p>You need one of the <a href="/faq#supported-devices">officially supported
+                    devices</a>. To make sure that the device can be unlocked to install GrapheneOS,
+                    avoid carrier variants of the devices. Carrier variants of Pixels use the same stock
+                    OS and firmware with a non-zero carrier id flashed onto the persist partition in the
+                    factory. The carrier id activates carrier-specific configuration in the stock OS
+                    including disabling carrier and bootloader unlocking. The carrier may be able to
+                    remotely disable this, but their support staff may not be aware and they probably
+                    won't do it. Get a carrier agnostic device to avoid the risk and potential hassle.
+                    If you CAN figure out a way to unlock a carrier device, it isn't a problem as
+                    GrapheneOS can just ignore the carrier id and the hardware is the same.</p>
+
+                    <p>GrapheneOS flashes the latest firmware early in the installation process, but 
+                    it's best practice to update the device before installing GrapheneOS.</p>
                 </section>
 
-                <section id="disabling-oem-unlocking">
-                    <h3><a href="#disabling-oem-unlocking">Disabling OEM unlocking</a></h3>
+                <section id="enabling-oem-unlocking">
+                    <h2><a href="#enabling-oem-unlocking">Enabling OEM unlocking</a></h2>
 
-                    <p>During first setup, the final screen will contain a toggle regarding OEM
-                    unlocking which is checked by default. This will disable OEM unlocking, which is
-                    recommended.</p>
+                    <p>OEM unlocking needs to be enabled from within the operating system.</p>
 
-                    <p>If you need to enable or disable OEM unlocking in the future, it can be done
-                    in the developer settings menu within the operating system.</p>
+                    <p>Enable the developer options menu by going to <b>Settings&#160;> About phone/tablet</b> and repeatedly
+                    pressing the <b>Build number</b> menu entry until developer mode is enabled.</p>
+
+                    <p>Next, go to <b>Settings&#160;>
+                    System&#160;> Developer options</b> and
+                    toggle on the <b>OEM unlocking</b> setting. On device model variants (SKUs) which
+                    support being sold as locked devices by carriers, enabling <b>OEM unlocking</b>
+                    requires internet access so that the stock OS can check if the device was sold as
+                    locked by a carrier.</p>
+
+                    <p>For the Pixel 6a, OEM unlocking won't work with the version of the stock OS
+                    from the factory. You need to update it to the June 2022 release or later via an
+                    over-the-air update. After you've updated it you'll also need to factory reset
+                    the device to fix OEM unlocking.</p>
                 </section>
 
-                <section id="verifying-installation">
-                    <h3><a href="#verifying-installation">Verifying installation</a></h3>
+                <section id="flashing-as-non-root">
+                    <h2><a href="#flashing-as-non-root">Flashing as non-root</a></h2>
 
-                    <p>The verified boot and attestation features provided by the supported
-                    devices can be used to verify that the hardware, firmware and GrapheneOS
-                    installation are genuine. Even if the computer you used to flash GrapheneOS
-                    was compromised and an attacker replaced GrapheneOS with their own malicious
-                    OS, it can be detected with these features.</p>
+                    <p>On traditional Linux distributions, USB devices cannot be used as non-root
+                    without udev rules for each type of device. This is not an issue for other
+                    platforms.</p>
 
-                    <p>Verified boot verifies the entirety of the firmware and OS images on every
-                    boot. The public key for the firmware images is burned into fuses in the SoC at
-                    the factory. Firmware security updates also update the rollback index burned
-                    into fuses to provide rollback protection.</p>
+                    <p>On Arch Linux, install the <code>android-udev</code> package. On Debian and
+                    Ubuntu, install the <code>android-sdk-platform-tools-common</code> package.</p>
+                </section>
 
-                    <p>The final firmware boot stage before the OS is responsible for verifying
-                    it. For the stock OS, it uses a hard-wired public key. Installing GrapheneOS
-                    flashes the GrapheneOS verified boot public key to the secure element. Each
-                    boot, this key is loaded and used to verify the OS. For both the stock OS and
-                    GrapheneOS, a rollback index based on the security patch level is loaded from
-                    the secure element to provide rollback protection.</p>
+                <section id="working-around-fwupd-bugs-on-linux-distributions">
+                    <h2><a href="#working-around-fwupd-bug-on-linux-distributions">Working around fwupd bugs on Linux distributions</a></h2>
 
-                    {% include "verified_boot_key_hash.html" %}
+                    <p>The fwupd software often used on Linux distributions for updating firmware is
+                    known to incorrectly connect to arbitrary devices using the fastboot protocol which
+                    will block using them for the intended purpose. This can result in receiving an
+                    error about the USB device already being in use (claimed) when trying to connect to
+                    it for the intended purpose.</p>
 
-                    <section id="hardware-based-attestation">
-                        <h3><a href="#hardware-based-attestation">Hardware-based attestation</a></h3>
+                    <p>You can stop fwupd with the following command:</p>
 
-                        <p>GrapheneOS provides our Auditor app for using a combination of the
-                        verified boot and attestation features to verify that the hardware,
-                        firmware and operating system are genuine along with providing other
-                        useful data from the hardware and operating system.</p>
+                    <pre>sudo systemctl stop fwupd.service</pre>
 
-                        <p>Since the purpose of Auditor is to obtain information about the device
-                        without trusting it to be honest, results aren't shown on the device being
-                        verified. You need a 2nd Android device running Auditor for local QR code
-                        based verification. You can also use our optional device integrity
-                        monitoring service for automatic scheduled verifications with support for
-                        email alerts.</p>
+                    <p>This doesn't disable the service and it will start again on reboot.</p>
+                </section>
 
-                        <p>See the <a href="https://attestation.app/tutorial">Auditor tutorial</a>
-                        for a guide.</p>
+                <section id="booting-into-the-bootloader-interface">
+                    <h2><a href="#booting-into-the-bootloader-interface">Booting into the bootloader interface</a></h2>
 
-                        <p>Auditor is primarily based on a pairing model where it generates a
-                        hardware backed signing key and hardware backed attestation signing key
-                        and pins them as part of the initial verification. The first verification
-                        is bootstrapped based on chaining trust to one of the Android attestation
-                        roots. After the first verification, it provides a highly secure system
-                        for obtaining information about the device going forward. An attacker
-                        could bypass the initial verification with a leaked attestation key or by
-                        proxying to another device with the device model, OS and patch level that
-                        the user is expecting. Proxying to another device will be addressed in the
-                        future with optional support for the hardware serial number attestation
-                        feature.</p>
+                    <p>You need to boot your device into the bootloader interface. To do this, you need
+                    to hold the volume down button while the device boots.</p>
+
+                    <p>The easiest approach is to reboot the device and begin holding the volume down
+                    button until it boots up into the bootloader interface.</p>
+
+                    <p>Alternatively, turn off the device, then boot it up while holding the volume
+                    down button during the boot process. You can either boot it with the power button
+                    or by plugging it in as required in the next section.</p>
+
+                    <p>This step is not complete until your device displays a red warning triangle
+                    and the words "Fastboot Mode".  You must not press the device's power button
+                    to activate the "Start" menu item, because the device must remain paused in
+                    Fastboot mode for the installer to connect to it.</p>
+                </section>
+
+                <section id="connecting-device">
+                    <h2><a href="#connecting-device">Connecting the device</a></h2>
+
+                    <p>Connect the device to the computer. On Linux, you'll need to do this again if
+                    you didn't have the udev rules set up when you connected it.</p>
+
+                    <p>Current Windows 10 and Windows 11 include a generic driver usable for fastboot
+                    and no longer require installing a driver for installation on the Pixel 4a (5G) or
+                    later. It isn't enough for legacy 4th generation Pixels due to the driver not
+                    handling fastbootd, so you still need the driver for those. Outdated Windows
+                    versions will still need the driver for non-obsolete devices too. You can obtain the
+                    driver from Windows Update which will detect it as an optional update when the
+                    device is booted into the bootloader interface and connected to the computer. Open
+                    Windows Update, run a check for updates and then open the "View optional updates"
+                    interface. Install the driver for the Android bootloader interface as an optional
+                    update, which will show up as "LeMobile Android Device" due to USB ID overlap. An
+                    alternative approach to obtaining the Windows fastboot driver is to obtain the <a
+                    href="https://developer.android.com/studio/run/win-usb">latest driver for
+                    Pixels</a> from Google and then <a href="https://developer.android.com/studio/run/oem-usb#InstallingDriver">manually
+                    install it with the Windows Device Manager</a>.</p>
+
+                    <p>For the Pixel Tablet, disconnect it from the stand before continuing. The stand
+                    uses USB to provide charging and audio output, but the tablet lacks support for
+                    using both the stand and USB port at the same time.</p>
+                </section>
+
+                <section id="unlocking-the-bootloader">
+                    <h2><a href="#unlocking-the-bootloader">Unlocking the bootloader</a></h2>
+
+                    <p>Press the button below to unlock the bootloader, which enables flashing
+                    the OS and firmware:</p>
+
+                    <div id="classic-unlock-container">
+                        <button id="unlock-bootloader-button" disabled="">Unlock bootloader</button>
+                        <p><strong id="unlock-bootloader-status"></strong></p>
+                    </div>
+
+                    <p>The command needs to be confirmed on the device and will wipe all data. Use one
+                    of the volume buttons to switch the selection to accepting it and the power button to
+                    confirm.</p>
+                </section>
+
+                <section id="obtaining-factory-images">
+                    <h2><a href="#obtaining-factory-images">Obtaining factory images</a></h2>
+
+                    <p>You need to obtain the GrapheneOS factory images for your device to proceed with
+                    the installation process.</p>
+
+                    <p>Press the button below to start the download:</p>
+
+                    <p><strong id="quota-warning-text" class="warning-text" hidden="hidden">Warning: browser
+                    is reporting a low storage quota, there might not be enough space for the image</strong></p>
+
+                    <div id="classic-download-container">
+                        <button id="download-release-button" disabled="">Download release</button>
+                        <p id="download-release-status-container" hidden="hidden">
+                            <strong id="download-release-status"></strong>
+                            <br/>
+                            <progress id="download-release-progress" hidden="hidden" max="1" value="0"></progress>
+                        </p>
+                    </div>
+                </section>
+
+                <section id="flashing-factory-images">
+                    <h2><a href="#flashing-factory-images">Flashing factory images</a></h2>
+
+                    <p>The initial install will be performed by flashing the factory images. This will
+                    replace the existing OS installation and wipe all the existing data.</p>
+
+                    <div id="classic-flash-container">
+                        <button id="flash-release-button" disabled="">Flash release</button>
+                        <p id="flash-release-status-container" hidden="hidden">
+                            <strong id="flash-release-status"></strong>
+                            <br/>
+                            <progress id="flash-release-progress" hidden="hidden" max="1" value="0"></progress>
+                            <button id="flash-reconnect-button" hidden="hidden"><strong>Reconnect device</strong></button>
+                        </p>
+                    </div>
+
+                    <p>Wait for the flashing process to complete. It will automatically handle
+                    flashing the firmware, rebooting into the bootloader interface and flashing the OS.
+                    Avoid interacting with the device until the flashing script is finished. Then,
+                    proceed to <a href="#locking-the-bootloader">locking the bootloader</a> before using
+                    the device as locking wipes the data again.</p>
+                </section>
+
+                <section id="locking-the-bootloader">
+                    <h2><a href="#locking-the-bootloader">Locking the bootloader</a></h2>
+
+                    <p>Locking the bootloader is important as it enables full verified boot. It also
+                    prevents using fastboot to flash, format or erase partitions.  Verified boot will
+                    detect modifications to any of the OS partitions and it will prevent reading any
+                    modified or corrupted data. If changes are detected, error correction data is used
+                    to attempt to obtain the original data at which point it's verified again which
+                    makes verified boot robust to non-malicious corruption.</p>
+
+                    <p>In the bootloader interface, set it to locked:</p>
+
+                    <div id="classic-lock-container">
+                        <button id="lock-bootloader-button" disabled="">Lock bootloader</button>
+                        <p><strong id="lock-bootloader-status"></strong></p>
+                    </div>
+
+                    <p>The command needs to be confirmed on the device and will wipe all data. Use one
+                    of the volume buttons to switch the selection to accepting it and the power button
+                    to confirm.</p>
+                </section>
+
+                <section id="post-installation">
+                    <h2><a href="#post-installation">Post-installation</a></h2>
+
+                    <section id="booting">
+                        <h3><a href="#booting">Booting</a></h3>
+
+                        <p>You've now successfully installed GrapheneOS and can boot it. Pressing the
+                        power button with the default Start option selected in the bootloader
+                        interface will boot the OS.</p>
+                    </section>
+
+                    <section id="disabling-oem-unlocking">
+                        <h3><a href="#disabling-oem-unlocking">Disabling OEM unlocking</a></h3>
+
+                        <p>During first setup, the final screen will contain a toggle regarding OEM
+                        unlocking which is checked by default. This will disable OEM unlocking, which is
+                        recommended.</p>
+
+                        <p>If you need to enable or disable OEM unlocking in the future, it can be done
+                        in the developer settings menu within the operating system.</p>
+                    </section>
+
+                    <section id="verifying-installation">
+                        <h3><a href="#verifying-installation">Verifying installation</a></h3>
+
+                        <p>The verified boot and attestation features provided by the supported
+                        devices can be used to verify that the hardware, firmware and GrapheneOS
+                        installation are genuine. Even if the computer you used to flash GrapheneOS
+                        was compromised and an attacker replaced GrapheneOS with their own malicious
+                        OS, it can be detected with these features.</p>
+
+                        <p>Verified boot verifies the entirety of the firmware and OS images on every
+                        boot. The public key for the firmware images is burned into fuses in the SoC at
+                        the factory. Firmware security updates also update the rollback index burned
+                        into fuses to provide rollback protection.</p>
+
+                        <p>The final firmware boot stage before the OS is responsible for verifying
+                        it. For the stock OS, it uses a hard-wired public key. Installing GrapheneOS
+                        flashes the GrapheneOS verified boot public key to the secure element. Each
+                        boot, this key is loaded and used to verify the OS. For both the stock OS and
+                        GrapheneOS, a rollback index based on the security patch level is loaded from
+                        the secure element to provide rollback protection.</p>
+
+                        {% include "verified_boot_key_hash.html" %}
+
+                        <section id="hardware-based-attestation">
+                            <h3><a href="#hardware-based-attestation">Hardware-based attestation</a></h3>
+
+                            <p>GrapheneOS provides our Auditor app for using a combination of the
+                            verified boot and attestation features to verify that the hardware,
+                            firmware and operating system are genuine along with providing other
+                            useful data from the hardware and operating system.</p>
+
+                            <p>Since the purpose of Auditor is to obtain information about the device
+                            without trusting it to be honest, results aren't shown on the device being
+                            verified. You need a 2nd Android device running Auditor for local QR code
+                            based verification. You can also use our optional device integrity
+                            monitoring service for automatic scheduled verifications with support for
+                            email alerts.</p>
+
+                            <p>See the <a href="https://attestation.app/tutorial">Auditor tutorial</a>
+                            for a guide.</p>
+
+                            <p>Auditor is primarily based on a pairing model where it generates a
+                            hardware backed signing key and hardware backed attestation signing key
+                            and pins them as part of the initial verification. The first verification
+                            is bootstrapped based on chaining trust to one of the Android attestation
+                            roots. After the first verification, it provides a highly secure system
+                            for obtaining information about the device going forward. An attacker
+                            could bypass the initial verification with a leaked attestation key or by
+                            proxying to another device with the device model, OS and patch level that
+                            the user is expecting. Proxying to another device will be addressed in the
+                            future with optional support for the hardware serial number attestation
+                            feature.</p>
+                        </section>
+                    </section>
+
+                    <section id="further-information">
+                        <h3><a href="#further-information">Further information</a></h3>
+
+                        <p>Please look through the <a href="/usage">usage guide</a> and
+                        <a href="/faq">FAQ</a> for more information. If you have further questions not
+                        covered by the site, join the <a href="/contact#community">official GrapheneOS
+                        chat channels</a> and ask the questions in the appropriate channel.</p>
+                    </section>
+
+                    <section id="replacing-grapheneos-with-the-stock-os">
+                        <h3><a href="#replacing-grapheneos-with-the-stock-os">Replacing GrapheneOS with the stock OS</a></h3>
+
+                        <p>Installation of the stock OS via the stock factory images is similar to the
+                        process described above but with
+                        <a href="https://flash.android.com/back-to-public">Google's web flashing
+                        tool</a>. However, before flashing and locking, there's an additional step to
+                        fully revert the device to a clean factory state.</p>
+
+                        <p>The GrapheneOS factory images flash a non-stock Android Verified Boot key which
+                        needs to be erased to fully revert back to a stock device state. Before flashing the
+                        stock factory images, you should boot the device into fastboot mode and make sure the
+                        bootloader is unlocked. Then erase the custom Android Verified Boot key to untrust it:</p>
+
+                        <button id="remove-custom-key-button" disabled="">Remove non-stock key</button>
+
+                        <p><strong id="remove-custom-key-status"></strong></p>
                     </section>
                 </section>
+            </div> 
+            
+            <div class="wizard-view-content">
+                
+                <ul class="wizard-breadcrumbs">
+                    <li class="active" data-step="1">1. Setup</li>
+                    <li data-step="2">2. OEM</li>
+                    <li data-step="3">3. Connect</li>
+                    <li data-step="4">4. Unlock</li>
+                    <li data-step="5">5. Flash</li>
+                    <li data-step="6">6. Lock</li>
+                </ul>
 
-                <section id="further-information">
-                    <h3><a href="#further-information">Further information</a></h3>
+                <div class="wizard-card active" data-step="1">
+                    <h3>Step 1: Environmental Check</h3>
+                    <p class="wizard-subtitle">Verify your hardware and environment to minimize the risk of failure.</p>
+                    
+                    <ul class="wizard-checklist">
+                        <li>
+                            <label>
+                                <input type="checkbox" class="prereq-trigger">
+                                <span><strong>Hardware Check:</strong> My computer has at least 2GB RAM and 32GB free storage space.</span>
+                            </label>
+                        </li>
+                        <li>
+                            <label>
+                                <input type="checkbox" class="prereq-trigger">
+                                <span><strong>USB Cable:</strong> I am using a high-quality USB cable connected directly to a rear port (desktop) or laptop port. (No external hubs or front panel ports).</span>
+                            </label>
+                        </li>
+                        <li>
+                            <label>
+                                <input type="checkbox" class="prereq-trigger">
+                                <span><strong>Browser Check:</strong> I am using an updated Chromium-based browser (Chrome, Edge, Brave with shields down) and I am <strong>not</strong> in Incognito mode.</span>
+                            </label>
+                        </li>
+                        <li>
+                            <label>
+                                <input type="checkbox" class="prereq-trigger">
+                                <span><strong>Device Status:</strong> My phone is an officially supported, carrier-agnostic Pixel updated to the latest stock OS firmware.</span>
+                            </label>
+                        </li>
+                        <li>
+                            <label>
+                                <input type="checkbox" class="prereq-trigger">
+                                <span><strong>Linux Users Only (Optional):</strong> I have configured udev rules and temporarily stopped `fwupd` (Non-Linux users check this to proceed).</span>
+                            </label>
+                        </li>
+                    </ul>
 
-                    <p>Please look through the <a href="/usage">usage guide</a> and
-                    <a href="/faq">FAQ</a> for more information. If you have further questions not
-                    covered by the site, join the <a href="/contact#community">official GrapheneOS
-                    chat channels</a> and ask the questions in the appropriate channel.</p>
-                </section>
+                    <div class="wizard-nav-actions">
+                        <div></div> <button class="btn-wizard-primary next-btn" disabled>Next: OEM Unlocking</button>
+                    </div>
+                </div>
 
-                <section id="replacing-grapheneos-with-the-stock-os">
-                    <h3><a href="#replacing-grapheneos-with-the-stock-os">Replacing GrapheneOS with the stock OS</a></h3>
+                <div class="wizard-card" data-step="2">
+                    <h3>Step 2: Enable OEM Unlocking</h3>
+                    <p class="wizard-subtitle">Allow your device's bootloader to be unlocked.</p>
+                    
+                    <ol class="wizard-instructions">
+                        <li>Boot into your current Android OS.</li>
+                        <li>Go to <strong>Settings > About phone</strong>.</li>
+                        <li>Scroll down and tap <strong>Build number</strong> repeatedly until developer mode enables.</li>
+                        <li>Go back, then navigate to <strong>Settings > System > Developer options</strong>.</li>
+                        <li>Toggle on <strong>OEM unlocking</strong>. <em>(Note: Requires internet connection. Pixel 6a requires June 2022+ update installed).</em></li>
+                    </ol>
 
-                    <p>Installation of the stock OS via the stock factory images is similar to the
-                    process described above but with
-                    <a href="https://flash.android.com/back-to-public">Google's web flashing
-                    tool</a>. However, before flashing and locking, there's an additional step to
-                    fully revert the device to a clean factory state.</p>
+                    <div class="wizard-nav-actions">
+                        <button class="btn-wizard-secondary prev-btn">Go Back</button>
+                        <button class="btn-wizard-primary next-btn">Next: Bootloader Mode</button>
+                    </div>
+                </div>
 
-                    <p>The GrapheneOS factory images flash a non-stock Android Verified Boot key which
-                    needs to be erased to fully revert back to a stock device state. Before flashing the
-                    stock factory images, you should boot the device into fastboot mode and make sure the
-                    bootloader is unlocked. Then erase the custom Android Verified Boot key to untrust it:</p>
+                <div class="wizard-card" data-step="3">
+                    <h3>Step 3: Bootloader Mode & Connection</h3>
+                    <p class="wizard-subtitle">Put your phone in the correct state to receive commands.</p>
+                    
+                    <ol class="wizard-instructions">
+                        <li>Turn off your device.</li>
+                        <li>Turn it back on while holding the <strong>Volume Down</strong> button.</li>
+                        <li>Wait until you see a red warning triangle and the words <strong>"Fastboot Mode"</strong>.</li>
+                        <li><strong>Do not press the power button</strong> to start the device. Leave it on this screen.</li>
+                        <li>Connect the device to your computer using your high-quality USB cable. <em>(Pixel Tablet users: disconnect from the stand)</em>.</li>
+                    </ol>
 
-                    <button id="remove-custom-key-button" disabled="">Remove non-stock key</button>
+                    <div class="wizard-nav-actions">
+                        <button class="btn-wizard-secondary prev-btn">Go Back</button>
+                        <button class="btn-wizard-primary next-btn">Next: Unlock Bootloader</button>
+                    </div>
+                </div>
 
-                    <p><strong id="remove-custom-key-status"></strong></p>
-                </section>
-            </section>
+                <div class="wizard-card" data-step="4">
+                    <h3>Step 4: Unlock the Bootloader</h3>
+                    <p class="wizard-subtitle">This will wipe all existing data on the device.</p>
+                    
+                    <div class="wizard-instructions">
+                        <p>1. Click the button below to send the unlock command.</p>
+                        <div id="wizard-unlock-container" class="interactive-container"></div>
+                        
+                        <p>2. Look at your phone. Use the <strong>Volume keys</strong> to select "Unlock the bootloader".</p>
+                        <p>3. Press the <strong>Power button</strong> to confirm.</p>
+                    </div>
+
+                    <div class="wizard-nav-actions">
+                        <button class="btn-wizard-secondary prev-btn">Go Back</button>
+                        <button class="btn-wizard-primary next-btn">Next: Flash OS</button>
+                    </div>
+                </div>
+
+                <div class="wizard-card" data-step="5">
+                    <h3>Step 5: Download & Flash GrapheneOS</h3>
+                    <p class="wizard-subtitle">Obtain the factory images and install the OS. Do not touch your phone during this process.</p>
+                    
+                    <div class="wizard-instructions">
+                        <p>1. Download the release for your specific device:</p>
+                        <div id="wizard-download-container" class="interactive-container"></div>
+                        
+                        <p>2. Once downloaded, flash the release to your phone:</p>
+                        <div id="wizard-flash-container" class="interactive-container"></div>
+                    </div>
+
+                    <div class="wizard-nav-actions">
+                        <button class="btn-wizard-secondary prev-btn">Go Back</button>
+                        <button class="btn-wizard-primary next-btn">Next: Lock Bootloader</button>
+                    </div>
+                </div>
+
+                <div class="wizard-card" data-step="6">
+                    <h3>Step 6: Lock Bootloader & Finish</h3>
+                    <p class="wizard-subtitle">Re-secure your device to enable full verified boot.</p>
+                    
+                    <div class="wizard-instructions">
+                        <p>1. Click the button below to send the lock command (this will wipe data a final time):</p>
+                        <div id="wizard-lock-container" class="interactive-container"></div>
+
+                        <p>2. On your phone, use the <strong>Volume keys</strong> to accept, and the <strong>Power button</strong> to confirm.</p>
+                        <p>3. Your phone will reboot. Press the Power button with "Start" selected to boot into GrapheneOS!</p>
+                        <p>4. <em>Highly Recommended:</em> During Android setup, go back to Developer Options and toggle <strong>OEM unlocking OFF</strong>.</p>
+                    </div>
+
+                    <div class="wizard-nav-actions">
+                        <button class="btn-wizard-secondary prev-btn">Go Back</button>
+                        <button class="btn-wizard-primary finish-btn">Complete Installation</button>
+                    </div>
+                </div>
+
+            </div>
         </main>
         {% include "footer.html" %}
     </body>

--- a/static/install/web.html
+++ b/static/install/web.html
@@ -468,38 +468,38 @@
                     <ul class="wizard-checklist">
                         <li>
                             <label>
-                                <input type="checkbox" class="prereq-trigger">
+                                <input type="checkbox" class="prereq-trigger"/>
                                 <span><strong>Hardware Check:</strong> My computer has at least 2GB RAM and 32GB free storage space.</span>
                             </label>
                         </li>
                         <li>
                             <label>
-                                <input type="checkbox" class="prereq-trigger">
+                                <input type="checkbox" class="prereq-trigger"/>
                                 <span><strong>USB Cable:</strong> I am using a high-quality USB cable connected directly to a rear port (desktop) or laptop port. (No external hubs or front panel ports).</span>
                             </label>
                         </li>
                         <li>
                             <label>
-                                <input type="checkbox" class="prereq-trigger">
+                                <input type="checkbox" class="prereq-trigger"/>
                                 <span><strong>Browser Check:</strong> I am using an updated Chromium-based browser (Chrome, Edge, Brave with shields down) and I am <strong>not</strong> in Incognito mode.</span>
                             </label>
                         </li>
                         <li>
                             <label>
-                                <input type="checkbox" class="prereq-trigger">
+                                <input type="checkbox" class="prereq-trigger"/>
                                 <span><strong>Device Status:</strong> My phone is an officially supported, carrier-agnostic Pixel updated to the latest stock OS firmware.</span>
                             </label>
                         </li>
                         <li>
                             <label>
-                                <input type="checkbox" class="prereq-trigger">
+                                <input type="checkbox" class="prereq-trigger"/>
                                 <span><strong>Linux Users Only (Optional):</strong> I have configured udev rules and temporarily stopped `fwupd` (Non-Linux users check this to proceed).</span>
                             </label>
                         </li>
                     </ul>
 
                     <div class="wizard-nav-actions">
-                        <div></div> <button class="btn-wizard-primary next-btn" disabled>Next: OEM Unlocking</button>
+                        <div></div> <button class="btn-wizard-primary next-btn" disabled="">Next: OEM Unlocking</button>
                     </div>
                 </div>
 
@@ -522,7 +522,7 @@
                 </div>
 
                 <div class="wizard-card" data-step="3">
-                    <h3>Step 3: Bootloader Mode & Connection</h3>
+                    <h3>Step 3: Bootloader Mode &amp; Connection</h3>
                     <p class="wizard-subtitle">Put your phone in the correct state to receive commands.</p>
                     
                     <ol class="wizard-instructions">
@@ -558,7 +558,7 @@
                 </div>
 
                 <div class="wizard-card" data-step="5">
-                    <h3>Step 5: Download & Flash GrapheneOS</h3>
+                    <h3>Step 5: Download &amp; Flash GrapheneOS</h3>
                     <p class="wizard-subtitle">Obtain the factory images and install the OS. Do not touch your phone during this process.</p>
                     
                     <div class="wizard-instructions">
@@ -576,7 +576,7 @@
                 </div>
 
                 <div class="wizard-card" data-step="6">
-                    <h3>Step 6: Lock Bootloader & Finish</h3>
+                    <h3>Step 6: Lock Bootloader &amp; Finish</h3>
                     <p class="wizard-subtitle">Re-secure your device to enable full verified boot.</p>
                     
                     <div class="wizard-instructions">

--- a/static/js/wizard.js
+++ b/static/js/wizard.js
@@ -96,7 +96,7 @@ document.addEventListener("DOMContentLoaded", () => {
         // Optional: Reset wizard or show success state
     });
 
-    // --- Step 1 checklist validation ---
+    // Step 1 checklist validation 
     const checkboxes = document.querySelectorAll(".prereq-trigger");
     const step1NextBtn = document.querySelector(".wizard-card[data-step=\"1\"] .next-btn");
 

--- a/static/js/wizard.js
+++ b/static/js/wizard.js
@@ -1,78 +1,78 @@
-document.addEventListener('DOMContentLoaded', () => {
-    const mainContainer = document.getElementById('web-install');
-    const toggleBtn = document.getElementById('toggle-wizard-btn');
+document.addEventListener("DOMContentLoaded", () => {
+    const mainContainer = document.getElementById("web-install");
+    const toggleBtn = document.getElementById("toggle-wizard-btn");
     
     let currentStep = 1;
     const totalSteps = 6;
 
-    // Mode toggling 
-    toggleBtn.addEventListener('click', () => {
-        if (mainContainer.classList.contains('classic-mode')) {
-            mainContainer.classList.replace('classic-mode', 'wizard-mode');
+    // Mode toggling
+    toggleBtn.addEventListener("click", () => {
+        if (mainContainer.classList.contains("classic-mode")) {
+            mainContainer.classList.replace("classic-mode", "wizard-mode");
             toggleBtn.innerText = "Switch to Full Technical Guide (Classic Mode)";
             updateWizardUI();
-            moveInteractiveElements('wizard');
+            moveInteractiveElements("wizard");
         } else {
-            mainContainer.classList.replace('wizard-mode', 'classic-mode');
+            mainContainer.classList.replace("wizard-mode", "classic-mode");
             toggleBtn.innerText = "Enable Guided Wizard (Easy Mode)";
-            moveInteractiveElements('classic');
+            moveInteractiveElements("classic");
         }
     });
 
     // Move functional installer buttons so IDs don't duplicate and break web-install.js
     function moveInteractiveElements(targetMode) {
-        // Define the IDs of the buttons/status containers 
+        // Define the IDs of the buttons/status containers you need to move
         const elementsToMove = [
-            { elId: 'unlock-bootloader-button', classicParent: 'classic-unlock-container', wizardParent: 'wizard-unlock-container' },
-            { elId: 'unlock-bootloader-status', classicParent: 'classic-unlock-container', wizardParent: 'wizard-unlock-container' },
+            { elId: "unlock-bootloader-button", classicParent: "classic-unlock-container", wizardParent: "wizard-unlock-container" },
+            { elId: "unlock-bootloader-status", classicParent: "classic-unlock-container", wizardParent: "wizard-unlock-container" },
             
-            { elId: 'download-release-button', classicParent: 'classic-download-container', wizardParent: 'wizard-download-container' },
-            { elId: 'download-release-status-container', classicParent: 'classic-download-container', wizardParent: 'wizard-download-container' },
+            { elId: "download-release-button", classicParent: "classic-download-container", wizardParent: "wizard-download-container" },
+            { elId: "download-release-status-container", classicParent: "classic-download-container", wizardParent: "wizard-download-container" },
             
-            { elId: 'flash-release-button', classicParent: 'classic-flash-container', wizardParent: 'wizard-flash-container' },
-            { elId: 'flash-release-status-container', classicParent: 'classic-flash-container', wizardParent: 'wizard-flash-container' },
+            { elId: "flash-release-button", classicParent: "classic-flash-container", wizardParent: "wizard-flash-container" },
+            { elId: "flash-release-status-container", classicParent: "classic-flash-container", wizardParent: "wizard-flash-container" },
             
-            { elId: 'lock-bootloader-button', classicParent: 'classic-lock-container', wizardParent: 'wizard-lock-container' },
-            { elId: 'lock-bootloader-status', classicParent: 'classic-lock-container', wizardParent: 'wizard-lock-container' }
+            { elId: "lock-bootloader-button", classicParent: "classic-lock-container", wizardParent: "wizard-lock-container" },
+            { elId: "lock-bootloader-status", classicParent: "classic-lock-container", wizardParent: "wizard-lock-container" }
         ];
 
         elementsToMove.forEach(item => {
             const el = document.getElementById(item.elId);
             if (!el) return; // Skip if it doesn't exist
 
-            const targetParent = document.getElementById(targetMode === 'wizard' ? item.wizardParent : item.classicParent);
+            const targetParent = document.getElementById(targetMode === "wizard" ? item.wizardParent : item.classicParent);
             if (targetParent) {
                 targetParent.appendChild(el);
             }
         });
     }
 
-    // Wizard navigation logic
+    // Wizard mavigation logic 
     const updateWizardUI = () => {
-        // Update cards
-        document.querySelectorAll('.wizard-card').forEach(card => {
-            if (parseInt(card.getAttribute('data-step')) === currentStep) {
-                card.classList.add('active');
+        // Update Cards
+        document.querySelectorAll(".wizard-card").forEach(card => {
+            if (parseInt(card.getAttribute("data-step")) === currentStep) {
+                card.classList.add("active");
             } else {
-                card.classList.remove('active');
+                card.classList.remove("active");
             }
         });
 
         // Update breadcrumbs
-        document.querySelectorAll('.wizard-breadcrumbs li').forEach(crumb => {
-            const stepNum = parseInt(crumb.getAttribute('data-step'));
-            crumb.classList.remove('active', 'completed');
+        document.querySelectorAll(".wizard-breadcrumbs li").forEach(crumb => {
+            const stepNum = parseInt(crumb.getAttribute("data-step"));
+            crumb.classList.remove("active", "completed");
             if (stepNum === currentStep) {
-                crumb.classList.add('active');
+                crumb.classList.add("active");
             } else if (stepNum < currentStep) {
-                crumb.classList.add('completed');
+                crumb.classList.add("completed");
             }
         });
     };
 
     // Next button listeners
-    document.querySelectorAll('.next-btn').forEach(btn => {
-        btn.addEventListener('click', () => {
+    document.querySelectorAll(".next-btn").forEach(btn => {
+        btn.addEventListener("click", () => {
             if (currentStep < totalSteps) {
                 currentStep++;
                 updateWizardUI();
@@ -81,8 +81,8 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     // Previous button listeners
-    document.querySelectorAll('.prev-btn').forEach(btn => {
-        btn.addEventListener('click', () => {
+    document.querySelectorAll(".prev-btn").forEach(btn => {
+        btn.addEventListener("click", () => {
             if (currentStep > 1) {
                 currentStep--;
                 updateWizardUI();
@@ -91,17 +91,18 @@ document.addEventListener('DOMContentLoaded', () => {
     });
     
     // Finish button listener
-    document.querySelector('.finish-btn')?.addEventListener('click', () => {
+    document.querySelector(".finish-btn")?.addEventListener("click", () => {
         alert("Installation flow complete. You can now toggle back to the classic mode to read Post-Installation verify steps.");
+        // Optional: Reset wizard or show success state
     });
 
-    // Step 1 checklist validation
-    const checkboxes = document.querySelectorAll('.prereq-trigger');
-    const step1NextBtn = document.querySelector('.wizard-card[data-step="1"] .next-btn');
+    // --- Step 1 checklist validation ---
+    const checkboxes = document.querySelectorAll(".prereq-trigger");
+    const step1NextBtn = document.querySelector(".wizard-card[data-step=\"1\"] .next-btn");
 
     checkboxes.forEach(box => {
-        box.addEventListener('change', () => {
-            const checkedCount = document.querySelectorAll('.prereq-trigger:checked').length;
+        box.addEventListener("change", () => {
+            const checkedCount = document.querySelectorAll(".prereq-trigger:checked").length;
             step1NextBtn.disabled = (checkedCount !== checkboxes.length);
         });
     });

--- a/static/js/wizard.js
+++ b/static/js/wizard.js
@@ -1,0 +1,108 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const mainContainer = document.getElementById('web-install');
+    const toggleBtn = document.getElementById('toggle-wizard-btn');
+    
+    let currentStep = 1;
+    const totalSteps = 6;
+
+    // Mode toggling 
+    toggleBtn.addEventListener('click', () => {
+        if (mainContainer.classList.contains('classic-mode')) {
+            mainContainer.classList.replace('classic-mode', 'wizard-mode');
+            toggleBtn.innerText = "Switch to Full Technical Guide (Classic Mode)";
+            updateWizardUI();
+            moveInteractiveElements('wizard');
+        } else {
+            mainContainer.classList.replace('wizard-mode', 'classic-mode');
+            toggleBtn.innerText = "Enable Guided Wizard (Easy Mode)";
+            moveInteractiveElements('classic');
+        }
+    });
+
+    // Move functional installer buttons so IDs don't duplicate and break web-install.js
+    function moveInteractiveElements(targetMode) {
+        // Define the IDs of the buttons/status containers 
+        const elementsToMove = [
+            { elId: 'unlock-bootloader-button', classicParent: 'classic-unlock-container', wizardParent: 'wizard-unlock-container' },
+            { elId: 'unlock-bootloader-status', classicParent: 'classic-unlock-container', wizardParent: 'wizard-unlock-container' },
+            
+            { elId: 'download-release-button', classicParent: 'classic-download-container', wizardParent: 'wizard-download-container' },
+            { elId: 'download-release-status-container', classicParent: 'classic-download-container', wizardParent: 'wizard-download-container' },
+            
+            { elId: 'flash-release-button', classicParent: 'classic-flash-container', wizardParent: 'wizard-flash-container' },
+            { elId: 'flash-release-status-container', classicParent: 'classic-flash-container', wizardParent: 'wizard-flash-container' },
+            
+            { elId: 'lock-bootloader-button', classicParent: 'classic-lock-container', wizardParent: 'wizard-lock-container' },
+            { elId: 'lock-bootloader-status', classicParent: 'classic-lock-container', wizardParent: 'wizard-lock-container' }
+        ];
+
+        elementsToMove.forEach(item => {
+            const el = document.getElementById(item.elId);
+            if (!el) return; // Skip if it doesn't exist
+
+            const targetParent = document.getElementById(targetMode === 'wizard' ? item.wizardParent : item.classicParent);
+            if (targetParent) {
+                targetParent.appendChild(el);
+            }
+        });
+    }
+
+    // Wizard navigation logic
+    const updateWizardUI = () => {
+        // Update cards
+        document.querySelectorAll('.wizard-card').forEach(card => {
+            if (parseInt(card.getAttribute('data-step')) === currentStep) {
+                card.classList.add('active');
+            } else {
+                card.classList.remove('active');
+            }
+        });
+
+        // Update breadcrumbs
+        document.querySelectorAll('.wizard-breadcrumbs li').forEach(crumb => {
+            const stepNum = parseInt(crumb.getAttribute('data-step'));
+            crumb.classList.remove('active', 'completed');
+            if (stepNum === currentStep) {
+                crumb.classList.add('active');
+            } else if (stepNum < currentStep) {
+                crumb.classList.add('completed');
+            }
+        });
+    };
+
+    // Next button listeners
+    document.querySelectorAll('.next-btn').forEach(btn => {
+        btn.addEventListener('click', () => {
+            if (currentStep < totalSteps) {
+                currentStep++;
+                updateWizardUI();
+            }
+        });
+    });
+
+    // Previous button listeners
+    document.querySelectorAll('.prev-btn').forEach(btn => {
+        btn.addEventListener('click', () => {
+            if (currentStep > 1) {
+                currentStep--;
+                updateWizardUI();
+            }
+        });
+    });
+    
+    // Finish button listener
+    document.querySelector('.finish-btn')?.addEventListener('click', () => {
+        alert("Installation flow complete. You can now toggle back to the classic mode to read Post-Installation verify steps.");
+    });
+
+    // Step 1 checklist validation
+    const checkboxes = document.querySelectorAll('.prereq-trigger');
+    const step1NextBtn = document.querySelector('.wizard-card[data-step="1"] .next-btn');
+
+    checkboxes.forEach(box => {
+        box.addEventListener('change', () => {
+            const checkedCount = document.querySelectorAll('.prereq-trigger:checked').length;
+            step1NextBtn.disabled = (checkedCount !== checkboxes.length);
+        });
+    });
+});


### PR DESCRIPTION
Add optional interactive UI wizard for web installer using existing buttons. I also removed some unnecessary wordage from the page (that in general needs much more work on the site in my opinion). I only added to the existing static site other than removing some wordage. All logic remains the same. 

I believe this will help more non-technical users adopt GrapheneOS. 



I tested on VS Code liveserver with these updates:

<link rel="stylesheet" href="../main.css">
<link rel="stylesheet" href="../css/wizard.css">
<link rel="manifest" href="/manifest.webmanifest"/>
<link rel="license" href="/LICENSE.txt"/>
<link rel="me" href="https://grapheneos.social/@GrapheneOS"/>
<script src="../js/redirect.js"></script>
<script type="module" src="../js/fastboot/ffe7e270/fastboot.min.mjs"></script>
<script src="../js/web-install.js"></script>
<script src="../js/wizard.js"></script>
