### PR TITLE
Update Vanadium build instructions

### DIFF
--- a/static/build.html
+++ b/static/build.html
@@ -839,7 +839,7 @@ git checkout <var>CORRECT_BRANCH_OR_TAG</var></pre>
 
                     <p>Fetch the Chromium sources:</p>
 
-                    <pre>fetch --nohooks android</pre>
+                    <pre>gclient sync --nohooks</pre>
 
                     <p>Sync to the latest stable release for Android (replace <code><var>VERSION</var></code> with
                     the correct value):</p>


### PR DESCRIPTION
Future Vanadium releases will include its `.gclient` file for applying its downstream changes. This requires using the under-the-hood `gclient` command insteaad.

Applicable to M150 releases or newer.