### PR TITLE
Add "How to invoke accessibility options" text to both static installer pages

### DIFF
--- a/static/install/cli.html
+++ b/static/install/cli.html
@@ -87,6 +87,7 @@
                         <a href="#post-installation">Post-installation</a>
                         <ul>
                             <li><a href="#booting">Booting</a></li>
+                            <li><a href="#accessibility">Accessibility</a></li>
                             <li><a href="#disabling-oem-unlocking">Disabling OEM unlocking</a></li>
                             <li>
                                 <a href="#verifying-installation">Verifying installation</a>
@@ -532,6 +533,16 @@ curl -O https://releases.grapheneos.org/<var>DEVICE_NAME</var>-install-<var>VERS
                     interface will boot the OS.</p>
                 </section>
 
+                <section id="accessibility">
+                    <h3><a href="#accessibility">Accessibility</a></h3>
+
+                    <p>If you need the contents of your screen spoken, hold down the two volume keys 
+                    on your device simultaneously until a vibration is felt and the device starts 
+                    speaking. If you need other accessibility options like larger text, tap the 
+                    "accessibility" button on the initial setup screen to get started configuring 
+                    the options you need.</p>
+                </section>
+                
                 <section id="disabling-oem-unlocking">
                     <h3><a href="#disabling-oem-unlocking">Disabling OEM unlocking</a></h3>
 

--- a/static/install/web.html
+++ b/static/install/web.html
@@ -65,6 +65,7 @@
                         <a href="#post-installation">Post-installation</a>
                         <ul>
                             <li><a href="#booting">Booting</a></li>
+                            <li><a href="#accessibility">Accessibility</a></li>
                             <li><a href="#disabling-oem-unlocking">Disabling OEM unlocking</a></li>
                             <li>
                                 <a href="#verifying-installation">Verifying installation</a>
@@ -355,6 +356,16 @@
                     interface will boot the OS.</p>
                 </section>
 
+                <section id="accessibility">
+                    <h3><a href="#accessibility">Accessibility</a></h3>
+
+                    <p>If you need the contents of your screen spoken, hold down the two volume keys 
+                    on your device simultaneously until a vibration is felt and the device starts 
+                    speaking. If you need other accessibility options like larger text, tap the 
+                    "accessibility" button on the initial setup screen to get started configuring 
+                    the options you need.</p>
+                </section>
+                
                 <section id="disabling-oem-unlocking">
                     <h3><a href="#disabling-oem-unlocking">Disabling OEM unlocking</a></h3>
 


### PR DESCRIPTION
Closes https://github.com/GrapheneOS/grapheneos.org/issues/1573