### PR TITLE
updated docs to include what iuser device state should b

### DIFF
--- a/static/install/web.html
+++ b/static/install/web.html
@@ -235,6 +235,11 @@
                 and the words "Fastboot Mode".  You must not press the device's power button
                 to activate the "Start" menu item, because the device must remain paused in
                 Fastboot mode for the installer to connect to it.</p>
+		
+		<p>NOTE: While in FastBootMode Device State should look like the following.
+		Device State: locked(unlockable). If you don't see unlockable you did not 
+		correctly unlock the bootloader. Try again in settings </p>
+
             </section>
 
             <section id="connecting-device">


### PR DESCRIPTION
I hit the toggle to unlock bootloader in settings -> enter boot menu couldnt unlock bootloadder

I know it seems easy and users should know... but it took me 3x going into settings and hitting the toggle untill it actually took the change on restart

woulda saved me time if docs mentioned what ideal device state shouldbe .. Maybe my wording could be diffrent & maybe belings in diffrent place in the docs??  lmk yall's thoughts on this addition thanks for maintaining good shit